### PR TITLE
Lucid Interface: Provide the ability to retrieve inputs

### DIFF
--- a/src/lucid/lucid.ts
+++ b/src/lucid/lucid.ts
@@ -96,6 +96,10 @@ export class Lucid {
     return this.provider.getUtxosWithUnit(address, unit);
   }
 
+  async inputsOf(utxo: UTxO, maxRetries: number = 5, backoff: number = 3000): Promise<Address[]> {
+    return this.provider.getInputs(utxo, maxRetries, backoff);
+  }
+
   async awaitTx(txHash: TxHash): Promise<boolean> {
     return this.provider.awaitTx(txHash);
   }

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -23,6 +23,7 @@ export interface ProviderSchema {
   getCurrentSlot(): Promise<Slot>;
   getUtxos(address: Address): Promise<UTxO[]>;
   getUtxosWithUnit?(address: Address, unit: Unit): Promise<UTxO[]>;
+  getInputs?(utxo: UTxO, maxRetries: number, backoff: number): Promise<Address[]>;
   getDatum?(datumHash: DatumHash): Promise<Datum>;
   awaitTx?(txHash: TxHash): Promise<boolean>;
   submitTx?(tx: Core.Transaction): Promise<TxHash>;


### PR DESCRIPTION
Pulling the address(es) that were inputs to the specified UTxO is a
common operation that can be used in, for example, vending machines that
automatically dispense NFTs.  This change provides a shim in the Lucid
class that accepts a UTxO and returns a list of all addresses that
provided input to that UTxO.

Note that we build in a backoff loop inside of the function due to
behavior we have seen from Blockfrost in the past where address and txn
APIs are inconsistent.  Addresses may return UTxOs that appear as if
they don't exist when the /txs endpoint is called. These flags can be
manually overridden by the calling application.

[ Documentation: Interfaces updated as needed ]
[ Testing: npm run build, npm test, deployed locally to separate app ]