### PR TITLE
I think that this needs a change..

### DIFF
--- a/src/plutus/time.ts
+++ b/src/plutus/time.ts
@@ -1,7 +1,7 @@
 import { Network, Slot, SlotConfig, UnixTime } from "../types/mod.ts";
 
 export const zeroTimeNetwork: Record<Network, UnixTime> = {
-  Mainnet: 1596059091000, // Shelley start (slotLength = 1s).
+  Mainnet: 1596049091000, // Shelley start (slotLength = 1s).
   Testnet: 1595967616000, // Shelley start (slotLength = 1s).
   Preview: 1660003200000, // Genesis start (slotLength = 1s).
   Preprod: 1654041600000, // Genesis start (slotLength = 1s).


### PR DESCRIPTION
Our staking portal does not work with the current version of lucid, I believe that this change is what is necessary in order to return functionality, we will simply offset tx bounds as required for now.

I could not (in a short time) find where these offsets can actually be referenced in any literature, but https://github.com/ADAOcommunity/round-table/blob/main/src/cardano/utils.ts uses a time similar to the one I have used in this PR.