### PR TITLE
Blockfrost: Only return empty UTxO list on 404

### DIFF
--- a/src/provider/blockfrost.ts
+++ b/src/provider/blockfrost.ts
@@ -55,11 +55,10 @@ export class Blockfrost implements Provider {
         { headers: { project_id: this.data.projectId } },
       ).then((res) => res.json());
       if ((pageResult as BlockfrostUtxoError).error) {
-        if ((pageResult as BlockfrostUtxoError).status_code === 400) return [];
-        else if ((pageResult as BlockfrostUtxoError).status_code === 500) {
-          throw new Error("Could not fetch UTxOs from Blockfrost. Try again.");
+        if ((pageResult as BlockfrostUtxoError).status_code === 404) {
+          return [];
         } else {
-          pageResult = [];
+          throw new Error("Could not fetch UTxOs from Blockfrost. Try again.");
         }
       }
       result = result.concat(pageResult as BlockfrostUtxoResult);
@@ -81,11 +80,10 @@ export class Blockfrost implements Provider {
         { headers: { project_id: this.data.projectId } },
       ).then((res) => res.json());
       if ((pageResult as BlockfrostUtxoError).error) {
-        if ((pageResult as BlockfrostUtxoError).status_code === 400) return [];
-        else if ((pageResult as BlockfrostUtxoError).status_code === 500) {
-          throw new Error("Could not fetch UTxOs from Blockfrost. Try again.");
+        if ((pageResult as BlockfrostUtxoError).status_code === 404) {
+          return [];
         } else {
-          pageResult = [];
+          throw new Error("Could not fetch UTxOs from Blockfrost. Try again.");
         }
       }
       result = result.concat(pageResult as BlockfrostUtxoResult);


### PR DESCRIPTION
[Blockfrost documentation](https://docs.blockfrost.io/#tag/Cardano-Addresses/paths/~1addresses~1{address}~1utxos~1{asset}/get) states that the /utxos/{asset} endpoint can return several different typs of error codes (e.g., 403, 418, 429) that do not indicate the address is empty but that the API key is misconfigured or another error occurred.  This change stops the error from being swallowed in this case so dApp developers do not get odd behavior when they were expecting an empty list to indicate truly no UTxOs available.

[ Documentation: None ]
[ Testing: deno task build, Hit blockfrost API using cURL to validate error codes ]