### PR TITLE
Add toPublic utility function to derive a public key from a private key

### DIFF
--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -121,6 +121,8 @@ export type TransactionWitnesses = string;
 export type Transaction = string;
 /** Bech32 */
 export type PrivateKey = string;
+/** Bech32 */
+export type PublicKey = string;
 /** Hex */
 export type ScriptRef = string;
 /** Hex */

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -18,6 +18,7 @@ import {
   Network,
   PolicyId,
   PrivateKey,
+  PublicKey,
   RewardAddress,
   Script,
   ScriptHash,
@@ -492,6 +493,10 @@ export function hexToUtf8(hex: string): string {
 
 export function utf8ToHex(utf8: string): string {
   return toHex(new TextEncoder().encode(utf8));
+}
+
+export function toPublic(privateKey: PrivateKey): PublicKey {
+  return C.PrivateKey.from_bech32(privateKey).to_public().to_bech32();
 }
 
 // WIP!! This is not finalized yet until CIP-0067 and CIP-0068 are merged


### PR DESCRIPTION
First of all, love Lucid.

I have been using Lucid and have come across a need to access the public key associated with a private key. Lucid, for good reason, does not expose the underlying core libraries so it would be helpful to bubble up this functionality so you can access it from Lucid and not have to install another package.

I added it as a utility function so that it can be imported as a standalone function and called without requiring an async call. 

[ Documentation: None]
[ Testing: deno task build, deno task test]