### PR TITLE
Update example to find utxo by datumHash

### DIFF
--- a/src/examples/matching_keyhash.ts
+++ b/src/examples/matching_keyhash.ts
@@ -80,8 +80,10 @@ export async function redeemUtxo(): Promise<TxHash> {
   );
 
   const datumHash = lucid.utils.datumToHash(redeemer);
+
   const utxos = await lucid.utxosAt(scriptAddress);
-  const utxo = utxos.find((utxo) => utxo.datumHash == datumHash);
+
+  const utxo = utxos.find((utxo) => utxo.datumHash === datumHash);
 
   const tx = await lucid.newTx().collectFrom([utxo], redeemer)
     .attachSpendingValidator(script)

--- a/src/examples/matching_keyhash.ts
+++ b/src/examples/matching_keyhash.ts
@@ -79,7 +79,9 @@ export async function redeemUtxo(): Promise<TxHash> {
     new Constr(0, [new Constr(0, [paymentCredential?.hash!])]),
   );
 
-  const [utxo] = await lucid.utxosAt(scriptAddress);
+  const datumHash = lucid.utils.datumToHash(redeemer);
+  const utxos = await lucid.utxosAt(scriptAddress);
+  const utxo = utxos.find((utxo) => utxo.datumHash == datumHash);
 
   const tx = await lucid.newTx().collectFrom([utxo], redeemer)
     .attachSpendingValidator(script)


### PR DESCRIPTION
I ran into the scenario where the address had multiple utxos, which resulted in an error when attempting to call `redeemUtxo()`;

This change fixes this by searching for the utxo with a match for the datumHash.

I believe this could also be a good way to showcase the use of the `datumToHash` method.

(I am fairly new to Plutus so do let me know if I'm doing anything wrong)