### PR TITLE
Add `utxos` option to `Tx.complete` method

### DIFF
--- a/src/lucid/tx.ts
+++ b/src/lucid/tx.ts
@@ -495,6 +495,7 @@ export class Tx {
   }
 
   async complete(options?: {
+    utxos?: TransactionUnspentOutputs;
     changeAddress?: Address;
     datum?: { asHash?: Datum; inline?: Datum };
     coinSelection?: boolean;
@@ -508,7 +509,7 @@ export class Tx {
       await task();
     }
 
-    const utxos = await this.lucid.wallet.getUtxosCore();
+    const utxos = options?.utxos || await this.lucid.wallet.getUtxosCore();
 
     const changeAddress: Core.Address = addressFromWithNetworkCheck(
       options?.changeAddress || (await this.lucid.wallet.address()),


### PR DESCRIPTION
I'm still learning the ins and outs of this lib and the serialization lib so this may not be necessary...

I'd like to control the utxo set that is passed to the coin selection algorithm during `Tx.complete()`. Currently, if coinSelection is enabled during `Tx.complete()` it will fetch the entire utxo set from the wallet by default. I'd like the option to pass specific a specific utxo set instead.

I imagine there is another way to do this - but this approach does work. I'll note that support for "single utxo" transactions would need to be added as well, the method below requires at least 2 utxos to work (this is because the add_inputs_from method is being used).

```js
// Create tx and create 1 output within the txBuilder
let tx = await lucid.newTx()
  .payToAddress(receiverAddr, { lovelace: 2000000n });

// Insert the first 2 utxos from an arbitrary number of utxos
const utxos = await lucid.wallet.getUtxos();
const coreUtxos = C.TransactionUnspentOutputs.new();
coreUtxos.add(utxoToCore(utxos[0]));
coreUtxos.add(utxoToCore(utxos[1]));
tx.txBuilder.add_inputs_from(coreUtxos, C.Address.from_bech32(changeAddr));

// Pass the 2 specified utxos to coin selection
tx = await tx.complete({
    utxos: coreUtxos,
});
```