### PR TITLE
Add an external Next.js example

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ Outputs a `dist` folder
 
 [View examples](./src/examples/)
 
+### More Examples
+
+* [Basic Next,js Blockfrost Proxy API Example](https://github.com/GGAlanSmithee/cardano-lucid-blockfrost-proxy-example)
+
 ### Basic usage
 
 ```js


### PR DESCRIPTION
According to the comment in https://github.com/spacebudz/lucid/pull/68#issuecomment-1233880752 you would welcome external examples @alessandrokonrad, well here is one :)

It's a very minimal example, but if you have any critique or input on the example itself, let me know.