### PR TITLE
conditionally polyfill node, to account for newer versions of node

### DIFF
--- a/src/core/core.ts
+++ b/src/core/core.ts
@@ -12,15 +12,15 @@ if (isNode) {
     /* webpackIgnore: true */ "@peculiar/webcrypto" as string
   );
   // @ts-ignore : global
-  global.crypto = new Crypto();
+  if (!global.crypto) global.crypto = new Crypto();
   // @ts-ignore : global
-  global.fetch = fetch.default;
+  if (!global.fetch) global.fetch = fetch.default;
   // @ts-ignore : global
-  global.Headers = fetch.Headers;
+  if (!global.Headers) global.Headers = fetch.Headers;
   // @ts-ignore : global
-  global.Request = fetch.Request;
+  if (!global.Request) global.Request = fetch.Request;
   // @ts-ignore : global
-  global.Response = fetch.Response;
+  if (!global.Response) global.Response = fetch.Response;
 }
 
 async function importForEnvironmentCore(): Promise<typeof Core | null> {


### PR DESCRIPTION
Potentially fixes https://github.com/spacebudz/lucid/issues/106.

Unfortunatley, I wasn't able to test this locally, because the package would not resolve when installting it from a local folder. Not sure what was going on, since this usually work. I also could not get the examples to work with the error `TypeError: Cannot convert undefined to a BigInt`. I couldn't run the tests either, with the error `error: TS2503 [ERROR]: Cannot find namespace 'Core'.` so I guess there is something wrong in my setup. I'm not used to  deno, so might be something related to that.

Even if I would have been able to properly test it, I'm not sure I would've been able to assert correction, since I don't know the intention for the polyfilling. If it's only for backward compatability, then this fix should be good.