### PR TITLE
handle there being no used address in selectWallet

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-  "deno.enable": true
+  "deno.enable": true,
+  "deno.lint": true
 }

--- a/src/lucid/lucid.ts
+++ b/src/lucid/lucid.ts
@@ -205,10 +205,11 @@ export class Lucid {
       // deno-lint-ignore require-await
       rewardAddress: async (): Promise<RewardAddress | null> => null,
       getUtxos: async (): Promise<UTxO[]> => {
-        return await this.utxosAt(await this.wallet.address());
+        const address = await this.wallet.address();
+        return address ? this.utxosAt(address) : [];
       },
       getUtxosCore: async (): Promise<Core.TransactionUnspentOutputs> => {
-        const utxos = await this.utxosAt(await this.wallet.address());
+        const utxos = await this.wallet.getUtxos();
         const coreUtxos = C.TransactionUnspentOutputs.new();
         utxos.forEach((utxo) => {
           coreUtxos.add(utxoToCore(utxo));
@@ -257,7 +258,7 @@ export class Lucid {
 
   selectWallet(api: WalletApi): Lucid {
     this.wallet = {
-      address: async (): Promise<Address> => {
+      address: async (): Promise<Address | null> => {
         const [addressHex] = await api.getUsedAddresses();
         const address = addressHex
           ? C.Address.from_bytes(fromHex(addressHex)).to_bech32(undefined)

--- a/src/lucid/lucid.ts
+++ b/src/lucid/lucid.ts
@@ -257,10 +257,13 @@ export class Lucid {
 
   selectWallet(api: WalletApi): Lucid {
     this.wallet = {
-      address: async (): Promise<Address> =>
-        C.Address.from_bytes(
-          fromHex((await api.getUsedAddresses())[0]),
-        ).to_bech32(undefined),
+      address: async (): Promise<Address> => {
+        const [addressHex] = await api.getUsedAddresses();
+        const address = addressHex
+          ? C.Address.from_bytes(fromHex(addressHex)).to_bech32(undefined)
+          : null;
+        return address
+      },
       rewardAddress: async (): Promise<RewardAddress | null> => {
         const [rewardAddressHex] = await api.getRewardAddresses();
         const rewardAddress = rewardAddressHex

--- a/src/lucid/tx.ts
+++ b/src/lucid/tx.ts
@@ -537,8 +537,14 @@ export class Tx {
 
     const utxos = await this.lucid.wallet.getUtxosCore();
 
+    const address = await this.lucid.wallet.address();
+    
+    if (!address) {
+      throw new Error("No address available."); // todo, use unused address
+    }
+
     const changeAddress: Core.Address = addressFromWithNetworkCheck(
-      options?.changeAddress || (await this.lucid.wallet.address()),
+      options?.changeAddress || address,
       this.lucid,
     );
 

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -176,7 +176,7 @@ export interface ExternalWallet {
 export type SignedMessage = { signature: string; key: string };
 
 export interface Wallet {
-  address(): Promise<Address>;
+  address(): Promise<Address | null>;
   rewardAddress(): Promise<RewardAddress | null>;
   getUtxos(): Promise<UTxO[]>;
   getUtxosCore(): Promise<Core.TransactionUnspentOutputs>;

--- a/tests/mod.test.ts
+++ b/tests/mod.test.ts
@@ -29,8 +29,12 @@ const lucid = await Lucid.new();
 lucid.selectWalletFromPrivateKey(privateKey);
 
 Deno.test("PaymentKeyHash length", async () => {
+  const address = await lucid.wallet.address();
+
+  assertNotEquals(address, null);
+
   const { paymentCredential } = lucid.utils.getAddressDetails(
-    await lucid.wallet.address(),
+    address as string,
   );
   if (paymentCredential) {
     assertEquals(fromHex(paymentCredential.hash).length, 28);
@@ -40,9 +44,13 @@ Deno.test("PaymentKeyHash length", async () => {
 });
 
 Deno.test("Address type", async () => {
+  const address = await lucid.wallet.address();
+
+  assertNotEquals(address, null);
+
   const {
     address: { bech32 },
-  } = lucid.utils.getAddressDetails(await lucid.wallet.address());
+  } = lucid.utils.getAddressDetails(address as string);
   const enterpriseAddress = C.EnterpriseAddress.from_address(
     C.Address.from_bech32(bech32),
   )!
@@ -53,8 +61,12 @@ Deno.test("Address type", async () => {
 });
 
 Deno.test("No reward address", async () => {
+  const address = await lucid.wallet.address();
+
+  assertNotEquals(address, null);
+
   const { stakeCredential } = lucid.utils.getAddressDetails(
-    await lucid.wallet.address(),
+    address as string,
   );
   assertEquals(stakeCredential, undefined);
   assertEquals(await lucid.wallet.rewardAddress(), null);


### PR DESCRIPTION
When using lucid with a newly created wallet in eternl, I was getting an error

```sh
RuntimeError: unreachable
    at cardano_multiplatform_lib_bg.86fef139.wasm:0x1bd173
    at cardano_multiplatform_lib_bg.86fef139.wasm:0x1ff48b
    at cardano_multiplatform_lib_bg.86fef139.wasm:0x2304ec
    at cardano_multiplatform_lib_bg.86fef139.wasm:0x230b8d
    at cardano_multiplatform_lib_bg.86fef139.wasm:0x21cf83
    at cardano_multiplatform_lib_bg.86fef139.wasm:0x8f62c
    at cardano_multiplatform_lib_bg.86fef139.wasm:0x1f27ed
    at cardano_multiplatform_lib_bg.86fef139.wasm:0x1ec0b4
    at Address.from_bytes (cardano_multiplatform_lib.js?9ce3:823:1)
    at Object.address (lucid.js?1eb6:187:34)
```

This PR does fixes the problem.

However, in the above case, with a newly created wallet, there is no `usedAddresses`, but there are `unusedAddresses`, which Lucid does not handle atm. I will send another PR that does include `unusedAddress()` in the WalletApi, but I don't know what the correct way to handle that would be, and why it's not included in the current api, so do with that as you wish!