### PR TITLE
add optional key to selectWallet and wallet

### DIFF
--- a/src/lucid/lucid.ts
+++ b/src/lucid/lucid.ts
@@ -258,7 +258,7 @@ export class Lucid {
     return this;
   }
 
-  selectWallet(api: WalletApi): Lucid {
+  selectWallet(api: WalletApi, key?: string): Lucid {
     const getAddressHex = async () => {
       const [addressHex] = await api.getUsedAddresses();
       if (addressHex) return addressHex;
@@ -268,6 +268,7 @@ export class Lucid {
     };
 
     this.wallet = {
+      key,
       address: async (): Promise<Address> =>
         C.Address.from_bytes(
           fromHex(await getAddressHex()),

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -185,6 +185,7 @@ export interface ExternalWallet {
 export type SignedMessage = { signature: string; key: string };
 
 export interface Wallet {
+  key?: string;
   address(): Promise<Address>;
   rewardAddress(): Promise<RewardAddress | null>;
   getUtxos(): Promise<UTxO[]>;


### PR DESCRIPTION
@alessandrokonrad 

this adds an optional `key?: string` to the `Wallet` type. It allows the user to pass the key when calling `lucid.selectWallet(api: WalletApi, key?: string)`.

This would be very useful in certain situation, for example when building a wallet selector component, to be able to easily differentiate the currently selected wallet from the newly selected wallet, etc.

Preferably, this information would be present in the `WalletApi` itself, but it is not. I opened an issue on this in the CIPs repo, https://github.com/cardano-foundation/CIPs/issues/419, but I haven't created a CIP and idk if it would be acceptable.

If this is something you think is reasonable, do you think it makes sense to also include this in the other `select*` functions?