### PR TITLE
remove testnet

### DIFF
--- a/docs/docs/getting-started/instantiate-lucid.md
+++ b/docs/docs/getting-started/instantiate-lucid.md
@@ -7,7 +7,7 @@ order: 0
 Lucid can be instantiated with a blockchain provider or without. Usually you
 want to select a provider in order to query data and submit transactions.
 Additionally you want to select a network. Lucid supports the `Mainnet`,
-`Testnet`, `Preprod` and `Preview` networks. If no network is selected `Mainnet`
+`Preprod` and `Preview` networks. If no network is selected `Mainnet`
 is chosen by default. Throughout the entire docs we are making use of the
 `Preprod` network.
 

--- a/src/plutus/time.ts
+++ b/src/plutus/time.ts
@@ -5,7 +5,6 @@ export const SLOT_CONFIG_NETWORK: Record<
   SlotConfig
 > = {
   Mainnet: { zeroTime: 1596059091000, zeroSlot: 4492800, slotLength: 1000 }, // Starting at Shelley era
-  Testnet: { zeroTime: 1595967616000, zeroSlot: 1598400, slotLength: 1000 }, // Starting at Shelley era
   Preview: { zeroTime: 1666656000000, zeroSlot: 0, slotLength: 1000 }, // Starting at Shelley era
   Preprod: {
     zeroTime: 1654041600000 + 1728000000,

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -157,7 +157,7 @@ export type OutRef = { txHash: TxHash; outputIndex: number };
 
 export type AddressType = "Base" | "Enterprise" | "Pointer" | "Reward";
 
-export type Network = "Mainnet" | "Testnet" | "Preview" | "Preprod" | "Custom";
+export type Network = "Mainnet" | "Preview" | "Preprod" | "Custom";
 
 export type AddressDetails = {
   type: AddressType;

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -524,8 +524,6 @@ export function coreToUtxo(coreUtxo: Core.TransactionUnspentOutput): UTxO {
 
 export function networkToId(network: Network): number {
   switch (network) {
-    case "Testnet":
-      return 0;
     case "Preview":
       return 0;
     case "Preprod":


### PR DESCRIPTION
This removes `Testnet` as a valid network target. This is a response to the de-facto deprecation of this network, as well as a direct response to [Blockfrost removing Testnet](https://github.com/blockfrost/openapi/commit/7bdcfe715ddfc1f41b2ad3faeb99a398445c5fd7)