### PR TITLE
Fix getDelegation on unregistered accounts

### DIFF
--- a/src/provider/kupmios.ts
+++ b/src/provider/kupmios.ts
@@ -163,8 +163,8 @@ export class Kupmios implements Provider {
           };
           res(
             {
-              poolId: delegation.delegate || null,
-              rewards: BigInt(delegation.rewards || 0),
+              poolId: delegation?.delegate || null,
+              rewards: BigInt(delegation?.rewards || 0),
             },
           );
           client.close();


### PR DESCRIPTION
Found a small issue in Kupmios, would run into an  error if the result of the delegation query returned an empty object(aka not found)
