### PR TITLE
fix: missing deno shim in esm build

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -12,7 +12,9 @@ await dnt.build({
   test: false,
   scriptModule: false,
   typeCheck: false,
-  shims: {},
+  shims: {
+    deno: true
+  },
   package: {
     ...packageInfo,
     engines: {


### PR DESCRIPTION
Without it, WASM fails to load for me in Node.js env.