### PR TITLE
fix typebox portable type annonation

### DIFF
--- a/src/plutus/data.ts
+++ b/src/plutus/data.ts
@@ -7,6 +7,7 @@ import {
   TSchema,
   Type,
 } from "https://deno.land/x/typebox@0.25.13/src/typebox.ts";
+export * from "https://deno.land/x/typebox@0.25.13/src/typebox.ts"
 import { C } from "../core/mod.ts";
 import { Datum, Exact, Json, Redeemer } from "../types/mod.ts";
 import { fromHex, fromText, toHex } from "../utils/utils.ts";


### PR DESCRIPTION
This patch fixes the following issue when a project needs to export a type declaration

## TS Config
`"declaration": true` is set in `tsconfig.json`

## Export Schema
```
export const CredentialSchema = Data.Enum([
  Data.Object({
    PublicKeyCredential: Data.Tuple([
      Data.Bytes({ minLength: 28, maxLength: 28 }),
    ]),
  }),
  Data.Object({
    ScriptCredential: Data.Tuple([
      Data.Bytes({ minLength: 28, maxLength: 28 }),
    ]),
  }),
]);
export type Credential = Data.Static<typeof CredentialSchema>;
export const Credential = CredentialSchema as unknown as Credential
```

## Error

```
The inferred type of 'CredentialSchema' cannot be named without a reference to '../../node_modules/lucid-cardano/types/deps/deno.land/x/typebox@0.25.13/src/typebox.js'. This is likely not portable. A type annotation is necessary.
```

