### PR TITLE
Free unused memory in Data.from

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,34 @@
 <p align="center">
-  <img width="100px" src="./logo/lucid.svg" align="center"/>
-  <h1 align="center">Lucid</h1>
-  <p align="center">Lucid is a library, which allows you to create Cardano transactions and off-chain code for your Plutus contracts in JavaScript, Deno and Node.js.</p>
+  <h1 align="center">Jucid</h1>
+  <p align="center">Jucid a fork of Lucid, which allows you to create Cardano transactions and off-chain code for your Plutus contracts in JavaScript, Deno and Node.js without worrying about memory leaks.</p>
 
 <p align="center">
-    <img src="https://img.shields.io/github/commit-activity/m/berry-pool/lucid?style=for-the-badge" />
-    <a href="https://www.npmjs.com/package/lucid-cardano">
-      <img src="https://img.shields.io/npm/v/lucid-cardano?style=for-the-badge" />
+    <img src="https://img.shields.io/github/commit-activity/m/yHSJ/jucid?style=for-the-badge" />
+    <a href="https://www.npmjs.com/package/jucid-cardano">
+      <img src="https://img.shields.io/npm/v/jucid-cardano?style=for-the-badge" />
     </a>
-     <a href="https://doc.deno.land/https://deno.land/x/lucid/mod.ts">
-      <img src="https://img.shields.io/readthedocs/cardano-lucid?style=for-the-badge" />
     </a>
-    <a href="https://www.npmjs.com/package/lucid-cardano">
-      <img src="https://img.shields.io/npm/dw/lucid-cardano?style=for-the-badge" />
+    <a href="https://www.npmjs.com/package/jucid-cardano">
+      <img src="https://img.shields.io/npm/dw/jucid-cardano?style=for-the-badge" />
     </a>
-    <img src="https://img.shields.io/npm/l/lucid-cardano?style=for-the-badge" />
-    <a href="https://twitter.com/spacebudzNFT">
-      <img src="https://img.shields.io/twitter/follow/spacebudzNFT?style=for-the-badge&logo=twitter" />
+    <img src="https://img.shields.io/npm/l/jucid-cardano?style=for-the-badge" />
+    <a href="https://twitter.com/JSHyCS">
+      <img src="https://img.shields.io/twitter/follow/JSHyCS?style=for-the-badge&logo=twitter" />
     </a>
   </p>
 
 </p>
+
+### Lucid Fork
+
+Jucid is JSHy's fork of Lucid (Jshy + Lucid = Jucid). Lucid accidentally introduces memory leaks into applications due to incorrect memory management of WASM objects. Jucid handles internal memory correctly, exposes new interfaces to allow you to management objects you use correclty, and is a drop-in replacement for Lucid. Once this fork is merged into Lucid, it is unlikely it will be maintained.
 
 ### Get started
 
 #### NPM
 
 ```
-npm install lucid-cardano
+npm install jucid-cardano
 ```
 
 #### Deno 🦕
@@ -35,19 +36,19 @@ npm install lucid-cardano
 For JavaScript and TypeScript
 
 ```js
-import { Lucid } from "https://deno.land/x/lucid@0.10.7/mod.ts";
+import { jucid } from "https://deno.land/x/jucid@1.0.0-alpha.1/mod.ts";
 ```
 
 #### Web
 
 ```html
 <script type="module">
-import { Lucid } from "https://unpkg.com/lucid-cardano@0.10.7/web/mod.js"
-// ...
+  import { Lucid } from "https://unpkg.com/jucid@1.0.0-alpha.1/web/mod.js";
+  // ...
 </script>
 ```
 
-### 
+###
 
 ### Build from source
 
@@ -61,31 +62,29 @@ Outputs a `dist` folder
 
 ### Examples
 
-- [Basic examples](./src/examples/)
-- [Next.js Blockfrost Proxy API Example](https://github.com/GGAlanSmithee/cardano-lucid-blockfrost-proxy-example)
+- Coming Soon
 
 ### Basic usage
 
 ```js
-// import { Blockfrost, Lucid } from "https://deno.land/x/lucid@0.10.7/mod.ts"; Deno
-import { Blockfrost, Lucid } from "lucid-cardano"; // NPM
+// import { Blockfrost, Lucid } from "https://deno.land/x/jucid@1.0.0-alpha.1/mod.ts"; Deno
+import { Blockfrost, Lucid } from "jucid-cardano"; // NPM
 
 const lucid = await Lucid.new(
   new Blockfrost("https://cardano-preview.blockfrost.io/api/v0", "<projectId>"),
-  "Preview",
+  "Preview"
 );
 
 // Assumes you are in a browser environment
 const api = await window.cardano.nami.enable();
 lucid.selectWallet(api);
 
-const tx = await lucid.newTx()
-  .payToAddress("addr...", { lovelace: 5000000n })
-  .complete();
-
-const signedTx = await tx.sign().complete();
+const tx = lucid.newTx().payToAddress("addr...", { lovelace: 5000000n });
+const completeTx = await tx.complete();
+const signedTx = await completeTx.sign();
 
 const txHash = await signedTx.submit();
+Freeables.free(tx, completeTx, signedTx);
 
 console.log(txHash);
 ```
@@ -114,7 +113,7 @@ deno task test:core
 
 ### Docs
 
-[View docs](https://doc.deno.land/https://deno.land/x/lucid/mod.ts) 📖
+[View docs](https://doc.deno.land/https://deno.land/x/jucid/mod.ts) 📖
 
 You can generate documentation with:
 
@@ -143,15 +142,3 @@ project's `package.json`. Otherwise you will get import issues.
 
 Contributions and PRs are welcome!\
 The [contribution instructions](./CONTRIBUTING.md).
-
-Join us on [Discord](https://discord.gg/82MWs63Tdm)!
-
-### Use Lucid with React
-
-[use-cardano](https://use-cardano.alangaming.com/) a React context, hook and set
-of components built on top of Lucid.
-
-### Use Lucid with Next.js
-
-[Cardano Starter Kit](https://cardano-starter-kit.alangaming.com/) a Next.js
-starter kit for building Cardano dApps.

--- a/docs/docs/getting-started/choose-provider.md
+++ b/docs/docs/getting-started/choose-provider.md
@@ -46,9 +46,9 @@ import { Lucid, Maestro } from "https://deno.land/x/lucid/mod.ts";
 
 const lucid = await Lucid.new(
   new Maestro({
-    network: "Preprod",  // For MAINNET: "Mainnet".
-    apiKey: "<Your-API-Key>",  // Get yours by visiting https://docs.gomaestro.org/docs/Getting-started/Sign-up-login.
-    turboSubmit: false  // Read about paid turbo transaction submission feature at https://docs.gomaestro.org/docs/Dapp%20Platform/Turbo%20Transaction.
+    network: "Preprod", // For MAINNET: "Mainnet".
+    apiKey: "<Your-API-Key>", // Get yours by visiting https://docs.gomaestro.org/docs/Getting-started/Sign-up-login.
+    turboSubmit: false, // Read about paid turbo transaction submission feature at https://docs.gomaestro.org/docs/Dapp%20Platform/Turbo%20Transaction.
   }),
   "Preprod", // For MAINNET: "Mainnet".
 );

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "lucid-cardano",
-  "version": "0.10.7",
+  "name": "jucid-cardano",
+  "version": "1.0.0-alpha.1",
   "license": "MIT",
-  "author": "Alessandro Konrad",
-  "description": "Lucid is a library, which allows you to create Cardano transactions and off-chain code for your Plutus contracts in JavaScript, Deno and Node.js.",
-  "repository": "https://github.com/spacebudz/lucid"
+  "author": "Josh Marchand",
+  "description": "Jucid is a fork of Lucid which allows you to create Cardano transactions and off-chain code for your Plutus contracts in JavaScript, Deno and Node.js without introducing memory leaks.",
+  "repository": "https://github.com/yHSJ/jucid"
 }

--- a/src/examples/pool_registration.ts
+++ b/src/examples/pool_registration.ts
@@ -1,8 +1,19 @@
-import { Blockfrost, C, fromHex, Lucid, PoolParams } from "../mod.ts";
+import {
+  Blockfrost,
+  C,
+  FreeableBucket,
+  Freeables,
+  fromHex,
+  Lucid,
+  PoolParams,
+} from "../mod.ts";
+
+/** When working with objects from the C module or objects that have fields we need to always free their memory when we're done to prevent memory leaks. A FreeableBucket is one way to do that.*/
+const bucket: FreeableBucket = [];
 
 const lucid = await Lucid.new(
   new Blockfrost("https://cardano-preview.blockfrost.io/api/v0", "<projectId>"),
-  "Preview",
+  "Preview"
 );
 
 lucid.selectWalletFromSeed("car rare ...");
@@ -10,18 +21,28 @@ lucid.selectWalletFromSeed("car rare ...");
 /** StakePoolSigningKey_ed25519 cborHex from the cardano-cli */
 const coldKey = C.PrivateKey.from_bytes(
   fromHex(
-    "58204de30f983ed860524d00059c7f2b1d63240fba805bee043604aa7ccb13d387e9",
-  ),
+    "58204de30f983ed860524d00059c7f2b1d63240fba805bee043604aa7ccb13d387e9"
+  )
 );
+bucket.push(coldKey);
 
 /** VrfVerificationKey_PraosVRF cborHex from the cardano-cli */
-const vrfKeyHash = C.VRFVKey.from_bytes(
+const vrfVKey = C.VRFVKey.from_bytes(
   fromHex(
-    "5820c9cf07d863c8a2351662c9759ca1d9858b536bab50ad575b5de161e1af18f887",
-  ),
-).hash().to_hex();
+    "5820c9cf07d863c8a2351662c9759ca1d9858b536bab50ad575b5de161e1af18f887"
+  )
+);
+bucket.push(vrfVKey);
 
-const poolId = coldKey.to_public().hash().to_bech32("pool");
+const vrfVKeyHash = vrfVKey.hash();
+bucket.push(vrfVKeyHash);
+const vrfKeyHash = vrfVKeyHash.to_hex();
+
+const publicKey = coldKey.to_public();
+bucket.push(publicKey);
+const publicKeyHash = publicKey.hash();
+bucket.push(publicKeyHash);
+const poolId = publicKeyHash.to_bech32("pool");
 
 const rewardOwnerAddress = (await lucid.wallet.rewardAddress())!;
 
@@ -37,13 +58,19 @@ const poolParams: PoolParams = {
   metadataUrl: "https://...", // metadata needs to be hosted already before registering the pool
 };
 
-const tx = await lucid.newTx()
-  .registerPool(poolParams).complete();
+const tx = lucid.newTx().registerPool(poolParams);
+bucket.push(tx);
+const completeTX = await lucid.newTx().registerPool(poolParams).complete();
+bucket.push(completeTX);
 
-const signedTx = await tx.sign()
+const signedTx = await completeTX
+  .sign()
   .signWithPrivateKey(coldKey.to_bech32())
   .complete();
+bucket.push(signedTx);
 
 const txHash = await signedTx.submit();
+
+Freeables.free(...bucket);
 
 console.log(txHash);

--- a/src/lucid/lucid.ts
+++ b/src/lucid/lucid.ts
@@ -91,6 +91,8 @@ export class Lucid {
     this.provider = provider || this.provider;
     this.network = network || this.network;
     this.wallet = lucid.wallet;
+
+    lucid.free();
     return this;
   }
 

--- a/src/lucid/lucid.ts
+++ b/src/lucid/lucid.ts
@@ -69,8 +69,12 @@ export class Lucid {
       const txBuilderConfig = getTransactionBuilderConfig(
         protocolParameters,
         slotConfig,
-        // deno-lint-ignore no-explicit-any
-        { url: (provider as any)?.url, projectId: (provider as any)?.projectId }
+        {
+          // deno-lint-ignore no-explicit-any
+          url: (provider as any)?.url,
+          // deno-lint-ignore no-explicit-any
+          projectId: (provider as any)?.projectId,
+        }
       );
       lucid.txBuilderConfig = txBuilderConfig;
     }

--- a/src/lucid/lucid.ts
+++ b/src/lucid/lucid.ts
@@ -20,10 +20,12 @@ import {
   OutRef,
   Payload,
   PrivateKey,
+  ProtocolParameters,
   Provider,
   RewardAddress,
   SignedMessage,
   Slot,
+  SlotConfig,
   Transaction,
   TxHash,
   Unit,
@@ -39,22 +41,29 @@ import { Message } from "./message.ts";
 import { SLOT_CONFIG_NETWORK } from "../plutus/time.ts";
 import { Constr, Data } from "../plutus/data.ts";
 import { Emulator } from "../provider/emulator.ts";
-import { getTransactionBuilderConfig } from "../utils/transaction_builder_config.ts";
 import { Freeable, Freeables } from "../utils/freeable.ts";
+import { getTransactionBuilderConfig } from "../utils/transaction_builder_config.ts";
 
 export class Lucid {
-  txBuilderConfig!: C.TransactionBuilderConfig;
+  protocolParameters?: ProtocolParameters;
+  slotConfig!: SlotConfig;
   wallet!: Wallet;
   provider!: Provider;
   network: Network = "Mainnet";
   utils!: Utils;
 
-  static async new(provider?: Provider, network?: Network): Promise<Lucid> {
+  static async new(
+    provider?: Provider,
+    network?: Network,
+    protocolParameters?: ProtocolParameters,
+  ): Promise<Lucid> {
     const lucid = new this();
     if (network) lucid.network = network;
+    if (protocolParameters) {
+      lucid.protocolParameters = protocolParameters;
+    }
     if (provider) {
       lucid.provider = provider;
-      const protocolParameters = await provider.getProtocolParameters();
 
       if (lucid.provider instanceof Emulator) {
         lucid.network = "Custom";
@@ -64,22 +73,33 @@ export class Lucid {
           slotLength: 1000,
         };
       }
-
-      const slotConfig = SLOT_CONFIG_NETWORK[lucid.network];
-      const txBuilderConfig = getTransactionBuilderConfig(
-        protocolParameters,
-        slotConfig,
-        {
-          // deno-lint-ignore no-explicit-any
-          url: (provider as any)?.url,
-          // deno-lint-ignore no-explicit-any
-          projectId: (provider as any)?.projectId,
-        },
-      );
-      lucid.txBuilderConfig = txBuilderConfig;
     }
+    if (provider && !lucid.protocolParameters) {
+      const protocolParameters = await provider.getProtocolParameters();
+      lucid.protocolParameters = protocolParameters;
+    }
+    lucid.slotConfig = SLOT_CONFIG_NETWORK[lucid.network];
+
     lucid.utils = new Utils(lucid);
     return lucid;
+  }
+
+  getTransactionBuilderConfig(): C.TransactionBuilderConfig {
+    if (!this.protocolParameters) {
+      throw new Error(
+        "Protocol parameters or slot config not set. Set a provider or iniatilize with protocol parameters.",
+      );
+    }
+    return getTransactionBuilderConfig(
+      this.protocolParameters,
+      this.slotConfig,
+      {
+        // deno-lint-ignore no-explicit-any
+        url: (this.provider as any)?.url,
+        // deno-lint-ignore no-explicit-any
+        projectId: (this.provider as any)?.projectId,
+      },
+    );
   }
 
   /**
@@ -91,12 +111,16 @@ export class Lucid {
       throw new Error("Cannot switch when on custom network.");
     }
     const lucid = await Lucid.new(provider, network);
-    this.txBuilderConfig = lucid.txBuilderConfig;
+    this.protocolParameters = lucid.protocolParameters;
+    this.slotConfig = lucid.slotConfig;
     this.provider = provider || this.provider;
+    // Given that protoclParameters and provider are optional we should fetch protocol parameters if they are not set when switiching providers
+    if (!this.protocolParameters && provider) {
+      this.protocolParameters = await provider.getProtocolParameters();
+    }
     this.network = network || this.network;
     this.wallet = lucid.wallet;
 
-    lucid.free();
     return this;
   }
 
@@ -550,9 +574,5 @@ export class Lucid {
 
     Freeables.free(...bucket);
     return this;
-  }
-
-  free() {
-    this.txBuilderConfig.free();
   }
 }

--- a/src/lucid/tx.ts
+++ b/src/lucid/tx.ts
@@ -41,7 +41,9 @@ export class Tx {
 
   constructor(lucid: Lucid) {
     this.lucid = lucid;
-    this.txBuilder = C.TransactionBuilder.new(this.lucid.txBuilderConfig);
+    this.txBuilder = C.TransactionBuilder.new(
+      lucid.getTransactionBuilderConfig(),
+    );
     this.tasks = [];
   }
 
@@ -216,10 +218,7 @@ export class Tx {
     this.tasks.push((that) => {
       const addressDetails = that.lucid.utils.getAddressDetails(rewardAddress);
 
-      if (
-        addressDetails.type !== "Reward" ||
-        !addressDetails.stakeCredential
-      ) {
+      if (addressDetails.type !== "Reward" || !addressDetails.stakeCredential) {
         throw new Error("Not a reward address provided.");
       }
       const credential = addressDetails.stakeCredential.type === "Key"
@@ -260,10 +259,7 @@ export class Tx {
     this.tasks.push((that) => {
       const addressDetails = that.lucid.utils.getAddressDetails(rewardAddress);
 
-      if (
-        addressDetails.type !== "Reward" ||
-        !addressDetails.stakeCredential
-      ) {
+      if (addressDetails.type !== "Reward" || !addressDetails.stakeCredential) {
         throw new Error("Not a reward address provided.");
       }
       const credential = addressDetails.stakeCredential.type === "Key"
@@ -293,10 +289,7 @@ export class Tx {
     this.tasks.push((that) => {
       const addressDetails = that.lucid.utils.getAddressDetails(rewardAddress);
 
-      if (
-        addressDetails.type !== "Reward" ||
-        !addressDetails.stakeCredential
-      ) {
+      if (addressDetails.type !== "Reward" || !addressDetails.stakeCredential) {
         throw new Error("Not a reward address provided.");
       }
       const credential = addressDetails.stakeCredential.type === "Key"
@@ -337,9 +330,7 @@ export class Tx {
         that.lucid,
       );
 
-      const certificate = C.Certificate.new_pool_registration(
-        poolRegistration,
-      );
+      const certificate = C.Certificate.new_pool_registration(poolRegistration);
 
       that.txBuilder.add_certificate(certificate, undefined);
     });
@@ -357,9 +348,7 @@ export class Tx {
       // This flag makes sure a pool deposit is not required
       poolRegistration.set_is_update(true);
 
-      const certificate = C.Certificate.new_pool_registration(
-        poolRegistration,
-      );
+      const certificate = C.Certificate.new_pool_registration(poolRegistration);
 
       that.txBuilder.add_certificate(certificate, undefined);
     });
@@ -412,9 +401,7 @@ export class Tx {
   addSigner(address: Address | RewardAddress): Tx {
     const addressDetails = this.lucid.utils.getAddressDetails(address);
 
-    if (
-      !addressDetails.paymentCredential && !addressDetails.stakeCredential
-    ) {
+    if (!addressDetails.paymentCredential && !addressDetails.stakeCredential) {
       throw new Error("Not a valid address.");
     }
 
@@ -532,8 +519,7 @@ export class Tx {
         options?.change?.outputData?.hash,
         options?.change?.outputData?.asHash,
         options?.change?.outputData?.inline,
-      ].filter((b) => b)
-        .length > 1
+      ].filter((b) => b).length > 1
     ) {
       throw new Error(
         "Not allowed to set hash, asHash and inline at the same time.",
@@ -573,9 +559,7 @@ export class Tx {
       (() => {
         if (options?.change?.outputData?.hash) {
           return C.Datum.new_data_hash(
-            C.DataHash.from_hex(
-              options.change.outputData.hash,
-            ),
+            C.DataHash.from_hex(options.change.outputData.hash),
           );
         } else if (options?.change?.outputData?.asHash) {
           this.txBuilder.add_plutus_data(
@@ -626,7 +610,10 @@ export class Tx {
 
 function attachScript(
   tx: Tx,
-  { type, script }:
+  {
+    type,
+    script,
+  }:
     | SpendingValidator
     | MintingPolicy
     | CertificateValidator
@@ -661,16 +648,11 @@ async function createPoolRegistration(
   });
 
   const metadata = poolParams.metadataUrl
-    ? await fetch(
-      poolParams.metadataUrl,
-    )
-      .then((res) => res.arrayBuffer())
+    ? await fetch(poolParams.metadataUrl).then((res) => res.arrayBuffer())
     : null;
 
   const metadataHash = metadata
-    ? C.PoolMetadataHash.from_bytes(
-      C.hash_blake2b256(new Uint8Array(metadata)),
-    )
+    ? C.PoolMetadataHash.from_bytes(C.hash_blake2b256(new Uint8Array(metadata)))
     : null;
 
   const relays = C.Relays.new();
@@ -727,10 +709,7 @@ async function createPoolRegistration(
       poolOwners,
       relays,
       metadataHash
-        ? C.PoolMetadata.new(
-          C.Url.new(poolParams.metadataUrl!),
-          metadataHash,
-        )
+        ? C.PoolMetadata.new(C.Url.new(poolParams.metadataUrl!), metadataHash)
         : undefined,
     ),
   );

--- a/src/lucid/tx.ts
+++ b/src/lucid/tx.ts
@@ -534,13 +534,14 @@ export class Tx {
         task = this.tasks.shift();
       }
 
+      // We don't free `utxos` as it is passed as an Option to the txBuilder and the ownership is passed when passing an Option
       const utxos = await this.lucid.wallet.getUtxosCore();
 
+      // We don't free `changeAddress` as it is passed as an Option to the txBuilder and the ownership is passed when passing an Option
       const changeAddress: C.Address = addressFromWithNetworkCheck(
         options?.change?.address || (await this.lucid.wallet.address()),
         this.lucid
       );
-      bucket.push(utxos, changeAddress);
 
       if (options?.coinSelection || options?.coinSelection === undefined) {
         this.txBuilder.add_inputs_from(

--- a/src/lucid/tx.ts
+++ b/src/lucid/tx.ts
@@ -22,14 +22,21 @@ import {
   WithdrawalValidator,
 } from "../types/mod.ts";
 import {
+  addressFromWithNetworkCheck,
+  attachScript,
+  createPoolRegistration,
+  getDatumFromOutputData,
+  getScriptWitness,
+  getStakeCredential,
+} from "../utils/cml.ts";
+import { type FreeableBucket, Freeables } from "../utils/freeable.ts";
+import {
   assetsToValue,
   fromHex,
-  networkToId,
   toHex,
   toScriptRef,
   utxoToCore,
 } from "../utils/mod.ts";
-import { applyDoubleCborEncoding } from "../utils/utils.ts";
 import { Lucid } from "./lucid.ts";
 import { TxComplete } from "./tx_complete.ts";
 
@@ -42,7 +49,7 @@ export class Tx {
   constructor(lucid: Lucid) {
     this.lucid = lucid;
     this.txBuilder = C.TransactionBuilder.new(
-      lucid.getTransactionBuilderConfig(),
+      lucid.getTransactionBuilderConfig()
     );
     this.tasks = [];
   }
@@ -50,15 +57,22 @@ export class Tx {
   /** Read data from utxos. These utxos are only referenced and not spent. */
   readFrom(utxos: UTxO[]): Tx {
     this.tasks.push(async (that) => {
-      for (const utxo of utxos) {
-        if (utxo.datumHash) {
-          utxo.datum = Data.to(await that.lucid.datumOf(utxo));
-          // Add datum to witness set, so it can be read from validators
-          const plutusData = C.PlutusData.from_bytes(fromHex(utxo.datum!));
-          that.txBuilder.add_plutus_data(plutusData);
+      const bucket: FreeableBucket = [];
+      try {
+        for (const utxo of utxos) {
+          if (utxo.datumHash) {
+            utxo.datum = Data.to(await that.lucid.datumOf(utxo));
+            // Add datum to witness set, so it can be read from validators
+            const plutusData = C.PlutusData.from_bytes(fromHex(utxo.datum!));
+            bucket.push(plutusData);
+            that.txBuilder.add_plutus_data(plutusData);
+          }
+          const coreUtxo = utxoToCore(utxo);
+          bucket.push(coreUtxo);
+          that.txBuilder.add_reference_input(coreUtxo);
         }
-        const coreUtxo = utxoToCore(utxo);
-        that.txBuilder.add_reference_input(coreUtxo);
+      } finally {
+        Freeables.free(...bucket);
       }
     });
     return this;
@@ -70,24 +84,26 @@ export class Tx {
    */
   collectFrom(utxos: UTxO[], redeemer?: Redeemer): Tx {
     this.tasks.push(async (that) => {
-      for (const utxo of utxos) {
-        if (utxo.datumHash && !utxo.datum) {
-          utxo.datum = Data.to(await that.lucid.datumOf(utxo));
+      const bucket: FreeableBucket = [];
+      try {
+        for (const utxo of utxos) {
+          if (utxo.datumHash && !utxo.datum) {
+            utxo.datum = Data.to(await that.lucid.datumOf(utxo));
+          }
+          const coreUtxo = utxoToCore(utxo);
+          bucket.push(coreUtxo);
+          // We don't free Options as the ownership is passed to the txBuilder
+          const scriptWitness = redeemer
+            ? getScriptWitness(
+                redeemer,
+                utxo.datumHash && utxo.datum ? utxo.datum : undefined
+              )
+            : undefined;
+
+          that.txBuilder.add_input(coreUtxo, scriptWitness);
         }
-        const coreUtxo = utxoToCore(utxo);
-        that.txBuilder.add_input(
-          coreUtxo,
-          (redeemer as undefined) &&
-            C.ScriptWitness.new_plutus_witness(
-              C.PlutusWitness.new(
-                C.PlutusData.from_bytes(fromHex(redeemer!)),
-                utxo.datumHash && utxo.datum
-                  ? C.PlutusData.from_bytes(fromHex(utxo.datum!))
-                  : undefined,
-                undefined,
-              ),
-            ),
-        );
+      } finally {
+        Freeables.free(...bucket);
       }
     });
     return this;
@@ -100,34 +116,32 @@ export class Tx {
    */
   mintAssets(assets: Assets, redeemer?: Redeemer): Tx {
     this.tasks.push((that) => {
-      const units = Object.keys(assets);
-      const policyId = units[0].slice(0, 56);
-      const mintAssets = C.MintAssets.new();
-      units.forEach((unit) => {
-        if (unit.slice(0, 56) !== policyId) {
-          throw new Error(
-            "Only one policy id allowed. You can chain multiple mintAssets functions together if you need to mint assets with different policy ids.",
-          );
-        }
-        mintAssets.insert(
-          C.AssetName.new(fromHex(unit.slice(56))),
-          C.Int.from_str(assets[unit].toString()),
-        );
-      });
-      const scriptHash = C.ScriptHash.from_bytes(fromHex(policyId));
-      that.txBuilder.add_mint(
-        scriptHash,
-        mintAssets,
-        redeemer
-          ? C.ScriptWitness.new_plutus_witness(
-            C.PlutusWitness.new(
-              C.PlutusData.from_bytes(fromHex(redeemer!)),
-              undefined,
-              undefined,
-            ),
-          )
-          : undefined,
-      );
+      const bucket: FreeableBucket = [];
+      try {
+        const units = Object.keys(assets);
+        const policyId = units[0].slice(0, 56);
+        const mintAssets = C.MintAssets.new();
+        bucket.push(mintAssets);
+        units.forEach((unit) => {
+          if (unit.slice(0, 56) !== policyId) {
+            throw new Error(
+              "Only one policy id allowed. You can chain multiple mintAssets functions together if you need to mint assets with different policy ids."
+            );
+          }
+          const assetName = C.AssetName.new(fromHex(unit.slice(56)));
+          const int = C.Int.from_str(assets[unit].toString());
+          // Int is being passed by value so we don't need to free it
+          bucket.push(assetName);
+          mintAssets.insert(assetName, int);
+        });
+        const scriptHash = C.ScriptHash.from_bytes(fromHex(policyId));
+        // We don't free Options as the ownership is passed to the txBuilder
+        const scriptWitness = redeemer ? getScriptWitness(redeemer) : undefined;
+        bucket.push(scriptHash);
+        that.txBuilder.add_mint(scriptHash, mintAssets, scriptWitness);
+      } finally {
+        Freeables.free(...bucket);
+      }
     });
     return this;
   }
@@ -135,11 +149,12 @@ export class Tx {
   /** Pay to a public key or native script address. */
   payToAddress(address: Address, assets: Assets): Tx {
     this.tasks.push((that) => {
-      const output = C.TransactionOutput.new(
-        addressFromWithNetworkCheck(address, that.lucid),
-        assetsToValue(assets),
-      );
+      const addr = addressFromWithNetworkCheck(address, that.lucid);
+      const value = assetsToValue(assets);
+
+      const output = C.TransactionOutput.new(addr, value);
       that.txBuilder.add_output(output);
+      Freeables.free(output, addr, value);
     });
     return this;
   }
@@ -148,45 +163,64 @@ export class Tx {
   payToAddressWithData(
     address: Address,
     outputData: Datum | OutputData,
-    assets: Assets,
+    assets: Assets
   ): Tx {
     this.tasks.push((that) => {
-      if (typeof outputData === "string") {
-        outputData = { asHash: outputData };
-      }
+      const bucket: FreeableBucket = [];
+      try {
+        if (typeof outputData === "string") {
+          outputData = { asHash: outputData };
+        }
 
-      if (
-        [outputData.hash, outputData.asHash, outputData.inline].filter((b) => b)
-          .length > 1
-      ) {
-        throw new Error(
-          "Not allowed to set hash, asHash and inline at the same time.",
-        );
-      }
+        if (
+          [outputData.hash, outputData.asHash, outputData.inline].filter(
+            (b) => b
+          ).length > 1
+        ) {
+          throw new Error(
+            "Not allowed to set hash, asHash and inline at the same time."
+          );
+        }
 
-      const output = C.TransactionOutput.new(
-        addressFromWithNetworkCheck(address, that.lucid),
-        assetsToValue(assets),
-      );
+        const addr = addressFromWithNetworkCheck(address, that.lucid);
+        const value = assetsToValue(assets);
+        const output = C.TransactionOutput.new(addr, value);
+        bucket.push(output, addr, value);
 
-      if (outputData.hash) {
-        output.set_datum(
-          C.Datum.new_data_hash(C.DataHash.from_hex(outputData.hash)),
-        );
-      } else if (outputData.asHash) {
-        const plutusData = C.PlutusData.from_bytes(fromHex(outputData.asHash));
-        output.set_datum(C.Datum.new_data_hash(C.hash_plutus_data(plutusData)));
-        that.txBuilder.add_plutus_data(plutusData);
-      } else if (outputData.inline) {
-        const plutusData = C.PlutusData.from_bytes(fromHex(outputData.inline));
-        output.set_datum(C.Datum.new_data(C.Data.new(plutusData)));
-      }
+        if (outputData.hash) {
+          const dataHash = C.DataHash.from_hex(outputData.hash);
+          const datum = C.Datum.new_data_hash(dataHash);
+          bucket.push(dataHash, datum);
+          output.set_datum(datum);
+        } else if (outputData.asHash) {
+          const plutusData = C.PlutusData.from_bytes(
+            fromHex(outputData.asHash)
+          );
+          const dataHash = C.hash_plutus_data(plutusData);
+          const datum = C.Datum.new_data_hash(dataHash);
+          bucket.push(plutusData, dataHash, datum);
+          output.set_datum(datum);
+          that.txBuilder.add_plutus_data(plutusData);
+        } else if (outputData.inline) {
+          const plutusData = C.PlutusData.from_bytes(
+            fromHex(outputData.inline)
+          );
+          const data = C.Data.new(plutusData);
+          const datum = C.Datum.new_data(data);
+          bucket.push(plutusData, data, datum);
+          output.set_datum(datum);
+        }
 
-      const script = outputData.scriptRef;
-      if (script) {
-        output.set_script_ref(toScriptRef(script));
+        const script = outputData.scriptRef;
+        if (script) {
+          const scriptRef = toScriptRef(script);
+          bucket.push(scriptRef);
+          output.set_script_ref(toScriptRef(script));
+        }
+        that.txBuilder.add_output(output);
+      } finally {
+        Freeables.free(...bucket);
       }
-      that.txBuilder.add_output(output);
     });
     return this;
   }
@@ -195,7 +229,7 @@ export class Tx {
   payToContract(
     address: Address,
     outputData: Datum | OutputData,
-    assets: Assets,
+    assets: Assets
   ): Tx {
     if (typeof outputData === "string") {
       outputData = { asHash: outputData };
@@ -203,7 +237,7 @@ export class Tx {
 
     if (!(outputData.hash || outputData.asHash || outputData.inline)) {
       throw new Error(
-        "No datum set. Script output becomes unspendable without datum.",
+        "No datum set. Script output becomes unspendable without datum."
       );
     }
     return this.payToAddressWithData(address, outputData, assets);
@@ -213,7 +247,7 @@ export class Tx {
   delegateTo(
     rewardAddress: RewardAddress,
     poolId: PoolId,
-    redeemer?: Redeemer,
+    redeemer?: Redeemer
   ): Tx {
     this.tasks.push((that) => {
       const addressDetails = that.lucid.utils.getAddressDetails(rewardAddress);
@@ -221,35 +255,18 @@ export class Tx {
       if (addressDetails.type !== "Reward" || !addressDetails.stakeCredential) {
         throw new Error("Not a reward address provided.");
       }
-      const credential = addressDetails.stakeCredential.type === "Key"
-        ? C.StakeCredential.from_keyhash(
-          C.Ed25519KeyHash.from_bytes(
-            fromHex(addressDetails.stakeCredential.hash),
-          ),
-        )
-        : C.StakeCredential.from_scripthash(
-          C.ScriptHash.from_bytes(
-            fromHex(addressDetails.stakeCredential.hash),
-          ),
-        );
-
-      that.txBuilder.add_certificate(
-        C.Certificate.new_stake_delegation(
-          C.StakeDelegation.new(
-            credential,
-            C.Ed25519KeyHash.from_bech32(poolId),
-          ),
-        ),
-        redeemer
-          ? C.ScriptWitness.new_plutus_witness(
-            C.PlutusWitness.new(
-              C.PlutusData.from_bytes(fromHex(redeemer!)),
-              undefined,
-              undefined,
-            ),
-          )
-          : undefined,
+      const credential = getStakeCredential(
+        addressDetails.stakeCredential.hash,
+        addressDetails.stakeCredential.type
       );
+
+      const keyHash = C.Ed25519KeyHash.from_bech32(poolId);
+      const delegation = C.StakeDelegation.new(credential, keyHash);
+      // We don't free Options as the ownership is passed to the txBuilder
+      const scriptWitness = redeemer ? getScriptWitness(redeemer) : undefined;
+      const certificate = C.Certificate.new_stake_delegation(delegation);
+      that.txBuilder.add_certificate(certificate, scriptWitness);
+      Freeables.free(keyHash, delegation, credential, certificate);
     });
     return this;
   }
@@ -262,24 +279,16 @@ export class Tx {
       if (addressDetails.type !== "Reward" || !addressDetails.stakeCredential) {
         throw new Error("Not a reward address provided.");
       }
-      const credential = addressDetails.stakeCredential.type === "Key"
-        ? C.StakeCredential.from_keyhash(
-          C.Ed25519KeyHash.from_bytes(
-            fromHex(addressDetails.stakeCredential.hash),
-          ),
-        )
-        : C.StakeCredential.from_scripthash(
-          C.ScriptHash.from_bytes(
-            fromHex(addressDetails.stakeCredential.hash),
-          ),
-        );
-
-      that.txBuilder.add_certificate(
-        C.Certificate.new_stake_registration(
-          C.StakeRegistration.new(credential),
-        ),
-        undefined,
+      const credential = getStakeCredential(
+        addressDetails.stakeCredential.hash,
+        addressDetails.stakeCredential.type
       );
+      const stakeRegistration = C.StakeRegistration.new(credential);
+      const certificate =
+        C.Certificate.new_stake_registration(stakeRegistration);
+
+      that.txBuilder.add_certificate(certificate, undefined);
+      Freeables.free(credential, stakeRegistration, certificate);
     });
     return this;
   }
@@ -292,32 +301,18 @@ export class Tx {
       if (addressDetails.type !== "Reward" || !addressDetails.stakeCredential) {
         throw new Error("Not a reward address provided.");
       }
-      const credential = addressDetails.stakeCredential.type === "Key"
-        ? C.StakeCredential.from_keyhash(
-          C.Ed25519KeyHash.from_bytes(
-            fromHex(addressDetails.stakeCredential.hash),
-          ),
-        )
-        : C.StakeCredential.from_scripthash(
-          C.ScriptHash.from_bytes(
-            fromHex(addressDetails.stakeCredential.hash),
-          ),
-        );
-
-      that.txBuilder.add_certificate(
-        C.Certificate.new_stake_deregistration(
-          C.StakeDeregistration.new(credential),
-        ),
-        redeemer
-          ? C.ScriptWitness.new_plutus_witness(
-            C.PlutusWitness.new(
-              C.PlutusData.from_bytes(fromHex(redeemer!)),
-              undefined,
-              undefined,
-            ),
-          )
-          : undefined,
+      const credential = getStakeCredential(
+        addressDetails.stakeCredential.hash,
+        addressDetails.stakeCredential.type
       );
+      const stakeDeregistration = C.StakeDeregistration.new(credential);
+      const certificate =
+        C.Certificate.new_stake_deregistration(stakeDeregistration);
+      // We don't free Options as the ownership is passed to the txBuilder
+      const scriptWitness = redeemer ? getScriptWitness(redeemer) : undefined;
+
+      that.txBuilder.add_certificate(certificate, scriptWitness);
+      Freeables.free(credential, stakeDeregistration, certificate);
     });
     return this;
   }
@@ -327,12 +322,13 @@ export class Tx {
     this.tasks.push(async (that) => {
       const poolRegistration = await createPoolRegistration(
         poolParams,
-        that.lucid,
+        that.lucid
       );
 
       const certificate = C.Certificate.new_pool_registration(poolRegistration);
 
       that.txBuilder.add_certificate(certificate, undefined);
+      Freeables.free(certificate, poolRegistration);
     });
     return this;
   }
@@ -342,13 +338,14 @@ export class Tx {
     this.tasks.push(async (that) => {
       const poolRegistration = await createPoolRegistration(
         poolParams,
-        that.lucid,
+        that.lucid
       );
 
       // This flag makes sure a pool deposit is not required
       poolRegistration.set_is_update(true);
 
       const certificate = C.Certificate.new_pool_registration(poolRegistration);
+      Freeables.free(poolRegistration, certificate);
 
       that.txBuilder.add_certificate(certificate, undefined);
     });
@@ -360,10 +357,11 @@ export class Tx {
    */
   retirePool(poolId: PoolId, epoch: number): Tx {
     this.tasks.push((that) => {
-      const certificate = C.Certificate.new_pool_retirement(
-        C.PoolRetirement.new(C.Ed25519KeyHash.from_bech32(poolId), epoch),
-      );
+      const keyHash = C.Ed25519KeyHash.from_bech32(poolId);
+      const poolRetirement = C.PoolRetirement.new(keyHash, epoch);
+      const certificate = C.Certificate.new_pool_retirement(poolRetirement);
       that.txBuilder.add_certificate(certificate, undefined);
+      Freeables.free(keyHash, poolRetirement, certificate);
     });
     return this;
   }
@@ -371,24 +369,15 @@ export class Tx {
   withdraw(
     rewardAddress: RewardAddress,
     amount: Lovelace,
-    redeemer?: Redeemer,
+    redeemer?: Redeemer
   ): Tx {
     this.tasks.push((that) => {
-      that.txBuilder.add_withdrawal(
-        C.RewardAddress.from_address(
-          addressFromWithNetworkCheck(rewardAddress, that.lucid),
-        )!,
-        C.BigNum.from_str(amount.toString()),
-        redeemer
-          ? C.ScriptWitness.new_plutus_witness(
-            C.PlutusWitness.new(
-              C.PlutusData.from_bytes(fromHex(redeemer!)),
-              undefined,
-              undefined,
-            ),
-          )
-          : undefined,
-      );
+      const addr = addressFromWithNetworkCheck(rewardAddress, that.lucid);
+      const rewardAddr = C.RewardAddress.from_address(addr)!;
+      const amountBigNum = C.BigNum.from_str(amount.toString());
+      const scriptWitness = redeemer ? getScriptWitness(redeemer) : undefined;
+      that.txBuilder.add_withdrawal(rewardAddr, amountBigNum, scriptWitness);
+      Freeables.free(addr, rewardAddr, amountBigNum, scriptWitness);
     });
     return this;
   }
@@ -405,9 +394,10 @@ export class Tx {
       throw new Error("Not a valid address.");
     }
 
-    const credential = addressDetails.type === "Reward"
-      ? addressDetails.stakeCredential!
-      : addressDetails.paymentCredential!;
+    const credential =
+      addressDetails.type === "Reward"
+        ? addressDetails.stakeCredential!
+        : addressDetails.paymentCredential!;
 
     if (credential.type === "Script") {
       throw new Error("Only key hashes are allowed as signers.");
@@ -418,9 +408,9 @@ export class Tx {
   /** Add a payment or stake key hash as a required signer of the transaction. */
   addSignerKey(keyHash: PaymentKeyHash | StakeKeyHash): Tx {
     this.tasks.push((that) => {
-      that.txBuilder.add_required_signer(
-        C.Ed25519KeyHash.from_bytes(fromHex(keyHash)),
-      );
+      const key = C.Ed25519KeyHash.from_bytes(fromHex(keyHash));
+      that.txBuilder.add_required_signer(key);
+      Freeables.free(key);
     });
     return this;
   }
@@ -428,9 +418,9 @@ export class Tx {
   validFrom(unixTime: UnixTime): Tx {
     this.tasks.push((that) => {
       const slot = that.lucid.utils.unixTimeToSlot(unixTime);
-      that.txBuilder.set_validity_start_interval(
-        C.BigNum.from_str(slot.toString()),
-      );
+      const slotNum = C.BigNum.from_str(slot.toString());
+      that.txBuilder.set_validity_start_interval(slotNum);
+      Freeables.free(slotNum);
     });
     return this;
   }
@@ -438,17 +428,18 @@ export class Tx {
   validTo(unixTime: UnixTime): Tx {
     this.tasks.push((that) => {
       const slot = that.lucid.utils.unixTimeToSlot(unixTime);
-      that.txBuilder.set_ttl(C.BigNum.from_str(slot.toString()));
+      const slotNum = C.BigNum.from_str(slot.toString());
+      that.txBuilder.set_ttl(slotNum);
+      Freeables.free(slotNum);
     });
     return this;
   }
 
   attachMetadata(label: Label, metadata: Json): Tx {
     this.tasks.push((that) => {
-      that.txBuilder.add_json_metadatum(
-        C.BigNum.from_str(label.toString()),
-        JSON.stringify(metadata),
-      );
+      const labelNum = C.BigNum.from_str(label.toString());
+      that.txBuilder.add_json_metadatum(labelNum, JSON.stringify(metadata));
+      Freeables.free(labelNum);
     });
     return this;
   }
@@ -456,11 +447,13 @@ export class Tx {
   /** Converts strings to bytes if prefixed with **'0x'**. */
   attachMetadataWithConversion(label: Label, metadata: Json): Tx {
     this.tasks.push((that) => {
+      const labelNum = C.BigNum.from_str(label.toString());
       that.txBuilder.add_json_metadatum_with_schema(
-        C.BigNum.from_str(label.toString()),
+        labelNum,
         JSON.stringify(metadata),
-        C.MetadataJsonSchema.BasicConversions,
+        C.MetadataJsonSchema.BasicConversions
       );
+      Freeables.free(labelNum);
     });
     return this;
   }
@@ -468,9 +461,11 @@ export class Tx {
   /** Explicitely set the network id in the transaction body. */
   addNetworkId(id: number): Tx {
     this.tasks.push((that) => {
-      that.txBuilder.set_network_id(
-        C.NetworkId.from_bytes(fromHex(id.toString(16).padStart(2, "0"))),
+      const networkId = C.NetworkId.from_bytes(
+        fromHex(id.toString(16).padStart(2, "0"))
       );
+      that.txBuilder.set_network_id(networkId);
+      Freeables.free(networkId);
     });
     return this;
   }
@@ -509,91 +504,78 @@ export class Tx {
     return this;
   }
 
+  free() {
+    this.txBuilder.free();
+  }
+
+  /** Completes the transaction. This might fail, you should free the txBuilder when you are done with it. */
   async complete(options?: {
     change?: { address?: Address; outputData?: OutputData };
     coinSelection?: boolean;
     nativeUplc?: boolean;
   }): Promise<TxComplete> {
-    if (
-      [
-        options?.change?.outputData?.hash,
-        options?.change?.outputData?.asHash,
-        options?.change?.outputData?.inline,
-      ].filter((b) => b).length > 1
-    ) {
-      throw new Error(
-        "Not allowed to set hash, asHash and inline at the same time.",
+    const bucket: FreeableBucket = [];
+    try {
+      if (
+        [
+          options?.change?.outputData?.hash,
+          options?.change?.outputData?.asHash,
+          options?.change?.outputData?.inline,
+        ].filter((b) => b).length > 1
+      ) {
+        throw new Error(
+          "Not allowed to set hash, asHash and inline at the same time."
+        );
+      }
+
+      let task = this.tasks.shift();
+      while (task) {
+        await task(this);
+        task = this.tasks.shift();
+      }
+
+      const utxos = await this.lucid.wallet.getUtxosCore();
+
+      const changeAddress: C.Address = addressFromWithNetworkCheck(
+        options?.change?.address || (await this.lucid.wallet.address()),
+        this.lucid
       );
-    }
+      bucket.push(utxos, changeAddress);
 
-    let task = this.tasks.shift();
-    while (task) {
-      await task(this);
-      task = this.tasks.shift();
-    }
+      if (options?.coinSelection || options?.coinSelection === undefined) {
+        this.txBuilder.add_inputs_from(
+          utxos,
+          changeAddress,
+          Uint32Array.from([
+            200, // weight ideal > 100 inputs
+            1000, // weight ideal < 100 inputs
+            1500, // weight assets if plutus
+            800, // weight assets if not plutus
+            800, // weight distance if not plutus
+            5000, // weight utxos
+          ])
+        );
+      }
 
-    const utxos = await this.lucid.wallet.getUtxosCore();
+      const { datum, plutusData } = getDatumFromOutputData(
+        options?.change?.outputData
+      );
+      if (plutusData) {
+        this.txBuilder.add_plutus_data(plutusData);
+      }
+      bucket.push(datum, plutusData);
+      this.txBuilder.balance(changeAddress, datum);
 
-    const changeAddress: C.Address = addressFromWithNetworkCheck(
-      options?.change?.address || (await this.lucid.wallet.address()),
-      this.lucid,
-    );
-
-    if (options?.coinSelection || options?.coinSelection === undefined) {
-      this.txBuilder.add_inputs_from(
+      const tx = await this.txBuilder.construct(
         utxos,
         changeAddress,
-        Uint32Array.from([
-          200, // weight ideal > 100 inputs
-          1000, // weight ideal < 100 inputs
-          1500, // weight assets if plutus
-          800, // weight assets if not plutus
-          800, // weight distance if not plutus
-          5000, // weight utxos
-        ]),
+        options?.nativeUplc === undefined ? true : options?.nativeUplc
       );
+
+      return new TxComplete(this.lucid, tx);
+    } finally {
+      Freeables.free(...bucket);
     }
-
-    this.txBuilder.balance(
-      changeAddress,
-      (() => {
-        if (options?.change?.outputData?.hash) {
-          return C.Datum.new_data_hash(
-            C.DataHash.from_hex(options.change.outputData.hash),
-          );
-        } else if (options?.change?.outputData?.asHash) {
-          this.txBuilder.add_plutus_data(
-            C.PlutusData.from_bytes(fromHex(options.change.outputData.asHash)),
-          );
-          return C.Datum.new_data_hash(
-            C.hash_plutus_data(
-              C.PlutusData.from_bytes(
-                fromHex(options.change.outputData.asHash),
-              ),
-            ),
-          );
-        } else if (options?.change?.outputData?.inline) {
-          return C.Datum.new_data(
-            C.Data.new(
-              C.PlutusData.from_bytes(
-                fromHex(options.change.outputData.inline),
-              ),
-            ),
-          );
-        } else {
-          return undefined;
-        }
-      })(),
-    );
-
-    return new TxComplete(
-      this.lucid,
-      await this.txBuilder.construct(
-        utxos,
-        changeAddress,
-        options?.nativeUplc === undefined ? true : options?.nativeUplc,
-      ),
-    );
   }
 
   /** Return the current transaction body in Hex encoded Cbor. */
@@ -606,128 +588,4 @@ export class Tx {
 
     return toHex(this.txBuilder.to_bytes());
   }
-}
-
-function attachScript(
-  tx: Tx,
-  {
-    type,
-    script,
-  }:
-    | SpendingValidator
-    | MintingPolicy
-    | CertificateValidator
-    | WithdrawalValidator,
-) {
-  if (type === "Native") {
-    return tx.txBuilder.add_native_script(
-      C.NativeScript.from_bytes(fromHex(script)),
-    );
-  } else if (type === "PlutusV1") {
-    return tx.txBuilder.add_plutus_script(
-      C.PlutusScript.from_bytes(fromHex(applyDoubleCborEncoding(script))),
-    );
-  } else if (type === "PlutusV2") {
-    return tx.txBuilder.add_plutus_v2_script(
-      C.PlutusScript.from_bytes(fromHex(applyDoubleCborEncoding(script))),
-    );
-  }
-  throw new Error("No variant matched.");
-}
-
-async function createPoolRegistration(
-  poolParams: PoolParams,
-  lucid: Lucid,
-): Promise<C.PoolRegistration> {
-  const poolOwners = C.Ed25519KeyHashes.new();
-  poolParams.owners.forEach((owner) => {
-    const { stakeCredential } = lucid.utils.getAddressDetails(owner);
-    if (stakeCredential?.type === "Key") {
-      poolOwners.add(C.Ed25519KeyHash.from_hex(stakeCredential.hash));
-    } else throw new Error("Only key hashes allowed for pool owners.");
-  });
-
-  const metadata = poolParams.metadataUrl
-    ? await fetch(poolParams.metadataUrl).then((res) => res.arrayBuffer())
-    : null;
-
-  const metadataHash = metadata
-    ? C.PoolMetadataHash.from_bytes(C.hash_blake2b256(new Uint8Array(metadata)))
-    : null;
-
-  const relays = C.Relays.new();
-  poolParams.relays.forEach((relay) => {
-    switch (relay.type) {
-      case "SingleHostIp": {
-        const ipV4 = relay.ipV4
-          ? C.Ipv4.new(
-            new Uint8Array(relay.ipV4.split(".").map((b) => parseInt(b))),
-          )
-          : undefined;
-        const ipV6 = relay.ipV6
-          ? C.Ipv6.new(fromHex(relay.ipV6.replaceAll(":", "")))
-          : undefined;
-        relays.add(
-          C.Relay.new_single_host_addr(
-            C.SingleHostAddr.new(relay.port, ipV4, ipV6),
-          ),
-        );
-        break;
-      }
-      case "SingleHostDomainName": {
-        relays.add(
-          C.Relay.new_single_host_name(
-            C.SingleHostName.new(
-              relay.port,
-              C.DNSRecordAorAAAA.new(relay.domainName!),
-            ),
-          ),
-        );
-        break;
-      }
-      case "MultiHost": {
-        relays.add(
-          C.Relay.new_multi_host_name(
-            C.MultiHostName.new(C.DNSRecordSRV.new(relay.domainName!)),
-          ),
-        );
-        break;
-      }
-    }
-  });
-
-  return C.PoolRegistration.new(
-    C.PoolParams.new(
-      C.Ed25519KeyHash.from_bech32(poolParams.poolId),
-      C.VRFKeyHash.from_hex(poolParams.vrfKeyHash),
-      C.BigNum.from_str(poolParams.pledge.toString()),
-      C.BigNum.from_str(poolParams.cost.toString()),
-      C.UnitInterval.from_float(poolParams.margin),
-      C.RewardAddress.from_address(
-        addressFromWithNetworkCheck(poolParams.rewardAddress, lucid),
-      )!,
-      poolOwners,
-      relays,
-      metadataHash
-        ? C.PoolMetadata.new(C.Url.new(poolParams.metadataUrl!), metadataHash)
-        : undefined,
-    ),
-  );
-}
-
-function addressFromWithNetworkCheck(
-  address: Address | RewardAddress,
-  lucid: Lucid,
-): C.Address {
-  const { type, networkId } = lucid.utils.getAddressDetails(address);
-
-  const actualNetworkId = networkToId(lucid.network);
-  if (networkId !== actualNetworkId) {
-    throw new Error(
-      `Invalid address: Expected address with network id ${actualNetworkId}, but got ${networkId}`,
-    );
-  }
-  return type === "Byron"
-    ? C.ByronAddress.from_base58(address).to_address()
-    : C.Address.from_bech32(address);
 }

--- a/src/lucid/tx_complete.ts
+++ b/src/lucid/tx_complete.ts
@@ -133,12 +133,19 @@ export class TxComplete {
       await task();
     }
 
-    this.witnessSetBuilder.add_existing(this.txComplete.witness_set());
-    const signedTx = C.Transaction.new(
-      this.txComplete.body(),
-      this.witnessSetBuilder.build(),
-      this.txComplete.auxiliary_data()
-    );
+    const bucket: FreeableBucket = [];
+    const txCompleteWitnessSet = this.txComplete.witness_set();
+    bucket.push(txCompleteWitnessSet);
+    this.witnessSetBuilder.add_existing(txCompleteWitnessSet);
+    const body = this.txComplete.body();
+    bucket.push(body);
+    const witnessSet = this.witnessSetBuilder.build();
+    bucket.push(witnessSet);
+    const auxiliaryData = this.txComplete.auxiliary_data();
+    bucket.push(auxiliaryData);
+    const signedTx = C.Transaction.new(body, witnessSet, auxiliaryData);
+
+    Freeables.free(...bucket);
     return new TxSigned(this.lucid, signedTx);
   }
 

--- a/src/lucid/tx_complete.ts
+++ b/src/lucid/tx_complete.ts
@@ -162,4 +162,10 @@ export class TxComplete {
     Freeables.free(body, hash);
     return txHash;
   }
+
+  /** Since this object has WASM parameters, we must use the free method to free the parameters */
+  free() {
+    this.txComplete.free();
+    this.witnessSetBuilder.free();
+  }
 }

--- a/src/lucid/tx_complete.ts
+++ b/src/lucid/tx_complete.ts
@@ -156,6 +156,10 @@ export class TxComplete {
 
   /** Return the transaction hash. */
   toHash(): TxHash {
-    return C.hash_transaction(this.txComplete.body()).to_hex();
+    const body = this.txComplete.body();
+    const hash = C.hash_transaction(body);
+    const txHash = hash.to_hex();
+    Freeables.free(body, hash);
+    return txHash;
   }
 }

--- a/src/lucid/tx_complete.ts
+++ b/src/lucid/tx_complete.ts
@@ -66,12 +66,17 @@ export class TxComplete {
 
   /** Add an extra signature from a private key. */
   signWithPrivateKey(privateKey: PrivateKey): TxComplete {
+    const bucket: FreeableBucket = [];
     const priv = C.PrivateKey.from_bech32(privateKey);
-    const witness = C.make_vkey_witness(
-      C.hash_transaction(this.txComplete.body()),
-      priv
-    );
+    bucket.push(priv);
+    const body = this.txComplete.body();
+    bucket.push(body);
+    const hash = C.hash_transaction(body);
+    bucket.push(hash);
+    const witness = C.make_vkey_witness(hash, priv);
+    bucket.push(witness);
     this.witnessSetBuilder.add_vkey(witness);
+    Freeables.free(...bucket);
     return this;
   }
 

--- a/src/lucid/tx_complete.ts
+++ b/src/lucid/tx_complete.ts
@@ -163,7 +163,7 @@ export class TxComplete {
     return txHash;
   }
 
-  /** Since this object has WASM parameters, we must use the free method to free the parameters */
+  /** Since this object has WASM fields, we must use the free method to free the fields */
   free() {
     this.txComplete.free();
     this.witnessSetBuilder.free();

--- a/src/lucid/tx_complete.ts
+++ b/src/lucid/tx_complete.ts
@@ -84,7 +84,9 @@ export class TxComplete {
   async partialSign(): Promise<TransactionWitnesses> {
     const witnesses = await this.lucid.wallet.signTx(this.txComplete);
     this.witnessSetBuilder.add_existing(witnesses);
-    return toHex(witnesses.to_bytes());
+    const bytes = witnesses.to_bytes();
+    witnesses.free();
+    return toHex(bytes);
   }
 
   /**

--- a/src/lucid/tx_complete.ts
+++ b/src/lucid/tx_complete.ts
@@ -123,6 +123,7 @@ export class TxComplete {
         fromHex(witness)
       );
       this.witnessSetBuilder.add_existing(witnessParsed);
+      witnessParsed.free();
     });
     return this;
   }

--- a/src/lucid/tx_complete.ts
+++ b/src/lucid/tx_complete.ts
@@ -59,6 +59,7 @@ export class TxComplete {
     this.tasks.push(async () => {
       const witnesses = await this.lucid.wallet.signTx(this.txComplete);
       this.witnessSetBuilder.add_existing(witnesses);
+      witnesses.free();
     });
     return this;
   }

--- a/src/lucid/tx_signed.ts
+++ b/src/lucid/tx_signed.ts
@@ -13,7 +13,7 @@ export class TxSigned {
 
   async submit(): Promise<TxHash> {
     return await (this.lucid.wallet || this.lucid.provider).submitTx(
-      toHex(this.txSigned.to_bytes()),
+      toHex(this.txSigned.to_bytes())
     );
   }
 
@@ -24,6 +24,14 @@ export class TxSigned {
 
   /** Return the transaction hash. */
   toHash(): TxHash {
-    return C.hash_transaction(this.txSigned.body()).to_hex();
+    const hash = C.hash_transaction(this.txSigned.body());
+    const txHash = hash.to_hex();
+    hash.free();
+    return txHash;
+  }
+
+  /** Since this object has WASM parameters, we must use the free method to free the parameters */
+  free() {
+    this.txSigned.free();
   }
 }

--- a/src/lucid/tx_signed.ts
+++ b/src/lucid/tx_signed.ts
@@ -30,7 +30,7 @@ export class TxSigned {
     return txHash;
   }
 
-  /** Since this object has WASM parameters, we must use the free method to free the parameters */
+  /** Since this object has WASM fields, we must use the free method to free the fields */
   free() {
     this.txSigned.free();
   }

--- a/src/plutus/data.ts
+++ b/src/plutus/data.ts
@@ -89,7 +89,7 @@ export const Data = {
   },
   Array: function <T extends TSchema>(
     items: T,
-    options?: { minItems?: number; maxItems?: number; uniqueItems?: boolean },
+    options?: { minItems?: number; maxItems?: number; uniqueItems?: boolean }
   ) {
     const array = Type.Array(items);
     replaceProperties(array, { dataType: "list", items });
@@ -103,7 +103,7 @@ export const Data = {
   Map: function <T extends TSchema, U extends TSchema>(
     keys: T,
     values: U,
-    options?: { minItems?: number; maxItems?: number },
+    options?: { minItems?: number; maxItems?: number }
   ) {
     const map = Type.Unsafe<Map<Data.Static<T>, Data.Static<U>>>({
       dataType: "map",
@@ -123,7 +123,7 @@ export const Data = {
    */
   Object: function <T extends TProperties>(
     properties: T,
-    options?: { hasConstr?: boolean },
+    options?: { hasConstr?: boolean }
   ) {
     const object = Type.Object(properties);
     replaceProperties(object, {
@@ -138,8 +138,8 @@ export const Data = {
         },
       ],
     });
-    object.anyOf[0].hasConstr = typeof options?.hasConstr === "undefined" ||
-      options.hasConstr;
+    object.anyOf[0].hasConstr =
+      typeof options?.hasConstr === "undefined" || options.hasConstr;
     return object;
   },
   Enum: function <T extends TSchema>(items: T[]) {
@@ -148,27 +148,28 @@ export const Data = {
       anyOf: items.map((item, index) =>
         item.anyOf[0].fields.length === 0
           ? {
-            ...item.anyOf[0],
-            index,
-          }
+              ...item.anyOf[0],
+              index,
+            }
           : {
-            dataType: "constructor",
-            title: (() => {
-              const title = item.anyOf[0].fields[0].title;
-              if (
-                (title as string).charAt(0) !==
+              dataType: "constructor",
+              title: (() => {
+                const title = item.anyOf[0].fields[0].title;
+                if (
+                  (title as string).charAt(0) !==
                   (title as string).charAt(0).toUpperCase()
-              ) {
-                throw new Error(
-                  `Enum '${title}' needs to start with an uppercase letter.`,
-                );
-              }
-              return item.anyOf[0].fields[0].title;
-            })(),
-            index,
-            fields: item.anyOf[0].fields[0].items ||
-              item.anyOf[0].fields[0].anyOf[0].fields,
-          }
+                ) {
+                  throw new Error(
+                    `Enum '${title}' needs to start with an uppercase letter.`
+                  );
+                }
+                return item.anyOf[0].fields[0].title;
+              })(),
+              index,
+              fields:
+                item.anyOf[0].fields[0].items ||
+                item.anyOf[0].fields[0].anyOf[0].fields,
+            }
       ),
     });
     return union;
@@ -179,7 +180,7 @@ export const Data = {
    */
   Tuple: function <T extends TSchema[]>(
     items: [...T],
-    options?: { hasConstr?: boolean },
+    options?: { hasConstr?: boolean }
   ) {
     const tuple = Type.Tuple(items);
     replaceProperties(tuple, {
@@ -198,7 +199,7 @@ export const Data = {
       (title as string).charAt(0) !== (title as string).charAt(0).toUpperCase()
     ) {
       throw new Error(
-        `Enum '${title}' needs to start with an uppercase letter.`,
+        `Enum '${title}' needs to start with an uppercase letter.`
       );
     }
     const literal = Type.Literal(title);
@@ -264,34 +265,51 @@ export const Data = {
  */
 function to<T = Data>(data: Exact<T>, type?: T): Datum | Redeemer {
   function serialize(data: Data): C.PlutusData {
+    const bucket: FreeableBucket = [];
     try {
       if (typeof data === "bigint") {
-        return C.PlutusData.new_integer(C.BigInt.from_str(data.toString()));
+        const integer = C.BigInt.from_str(data.toString());
+        bucket.push(integer);
+        return C.PlutusData.new_integer(integer);
       } else if (typeof data === "string") {
         return C.PlutusData.new_bytes(fromHex(data));
       } else if (data instanceof Constr) {
         const { index, fields } = data;
         const plutusList = C.PlutusList.new();
+        bucket.push(plutusList);
+        fields.forEach((field) => {
+          const serializedField = serialize(field);
+          plutusList.add(serializedField);
+          bucket.push(serializedField);
+        });
 
-        fields.forEach((field) => plutusList.add(serialize(field)));
-
-        return C.PlutusData.new_constr_plutus_data(
-          C.ConstrPlutusData.new(
-            C.BigNum.from_str(index.toString()),
-            plutusList,
-          ),
+        const constrIndex = C.BigNum.from_str(index.toString());
+        bucket.push(constrIndex);
+        const cosntrPlutusData = C.ConstrPlutusData.new(
+          constrIndex,
+          plutusList
         );
+        bucket.push(cosntrPlutusData);
+        return C.PlutusData.new_constr_plutus_data(cosntrPlutusData);
       } else if (data instanceof Array) {
         const plutusList = C.PlutusList.new();
-
-        data.forEach((arg) => plutusList.add(serialize(arg)));
+        bucket.push(plutusList);
+        data.forEach((arg) => {
+          const serializedArg = serialize(arg);
+          plutusList.add(serializedArg);
+          bucket.push(serializedArg);
+        });
 
         return C.PlutusData.new_list(plutusList);
       } else if (data instanceof Map) {
         const plutusMap = C.PlutusMap.new();
-
+        bucket.push(plutusMap);
         for (const [key, value] of data.entries()) {
-          plutusMap.insert(serialize(key), serialize(value));
+          const serializedKey = serialize(key);
+          bucket.push(serializedKey);
+          const serializedValue = serialize(value);
+          bucket.push(serializedValue);
+          plutusMap.insert(serializedKey, serializedValue);
         }
 
         return C.PlutusData.new_map(plutusMap);
@@ -299,10 +317,15 @@ function to<T = Data>(data: Exact<T>, type?: T): Datum | Redeemer {
       throw new Error("Unsupported type");
     } catch (error) {
       throw new Error("Could not serialize the data: " + error);
+    } finally {
+      Freeables.free(...bucket);
     }
   }
   const d = type ? castTo<T>(data, type) : (data as Data);
-  return toHex(serialize(d).to_bytes()) as Datum | Redeemer;
+  const serializedD = serialize(d);
+  const result = toHex(serializedD.to_bytes()) as Datum | Redeemer;
+  serializedD.free();
+  return result;
 }
 
 /**
@@ -408,15 +431,14 @@ function toJson(plutusData: Data): Json {
         !isNaN(parseInt(data)) &&
         data.slice(-1) === "n")
     ) {
-      const bigint = typeof data === "string"
-        ? BigInt(data.slice(0, -1))
-        : data;
+      const bigint =
+        typeof data === "string" ? BigInt(data.slice(0, -1)) : data;
       return parseInt(bigint.toString());
     }
     if (typeof data === "string") {
       try {
         return new TextDecoder(undefined, { fatal: true }).decode(
-          fromHex(data),
+          fromHex(data)
         );
       } catch (_) {
         return "0x" + toHex(fromHex(data));
@@ -432,7 +454,7 @@ function toJson(plutusData: Data): Json {
           typeof convertedKey !== "number"
         ) {
           throw new Error(
-            "Unsupported type (Note: Only bytes or integers can be keys of a JSON object)",
+            "Unsupported type (Note: Only bytes or integers can be keys of a JSON object)"
           );
         }
         tempJson[convertedKey] = fromData(value);
@@ -440,7 +462,7 @@ function toJson(plutusData: Data): Json {
       return tempJson;
     }
     throw new Error(
-      "Unsupported type (Note: Constructor cannot be converted to JSON)",
+      "Unsupported type (Note: Constructor cannot be converted to JSON)"
     );
   }
   return fromData(plutusData);
@@ -484,14 +506,14 @@ function castFrom<T = Data>(data: Data, type: T): T {
         const fields: Record<string, T> = {};
         if (shape.fields.length !== data.fields.length) {
           throw new Error(
-            "Could not type cast to object. Fields do not match.",
+            "Could not type cast to object. Fields do not match."
           );
         }
         shape.fields.forEach((field: Json, fieldIndex: number) => {
           const title = field.title || "wrapper";
           if (/[A-Z]/.test(title[0])) {
             throw new Error(
-              "Could not type cast to object. Object properties need to start with a lowercase letter.",
+              "Could not type cast to object. Object properties need to start with a lowercase letter."
             );
           }
           fields[title] = castFrom<T>(data.fields[fieldIndex], field);
@@ -510,7 +532,7 @@ function castFrom<T = Data>(data: Data, type: T): T {
           const title = field.title || "wrapper";
           if (/[A-Z]/.test(title[0])) {
             throw new Error(
-              "Could not type cast to object. Object properties need to start with a lowercase letter.",
+              "Could not type cast to object. Object properties need to start with a lowercase letter."
             );
           }
           fields[title] = castFrom<T>(data[fieldIndex], field);
@@ -530,7 +552,7 @@ function castFrom<T = Data>(data: Data, type: T): T {
       }
 
       const enumShape = shape.anyOf.find(
-        (entry: Json) => entry.index === data.index,
+        (entry: Json) => entry.index === data.index
       );
       if (!enumShape || enumShape.fields.length !== data.fields.length) {
         throw new Error("Could not type cast to enum.");
@@ -573,7 +595,7 @@ function castFrom<T = Data>(data: Data, type: T): T {
           } else {
             if (!/[A-Z]/.test(enumShape.title)) {
               throw new Error(
-                "Could not type cast to enum. Enums need to start with an uppercase letter.",
+                "Could not type cast to enum. Enums need to start with an uppercase letter."
               );
             }
 
@@ -584,14 +606,14 @@ function castFrom<T = Data>(data: Data, type: T): T {
             // check if named args
             const args = enumShape.fields[0].title
               ? Object.fromEntries(
-                enumShape.fields.map((field: Json, index: number) => [
-                  field.title,
-                  castFrom<T>(data.fields[index], field),
-                ]),
-              )
+                  enumShape.fields.map((field: Json, index: number) => [
+                    field.title,
+                    castFrom<T>(data.fields[index], field),
+                  ])
+                )
               : enumShape.fields.map((field: Json, index: number) =>
-                castFrom<T>(data.fields[index], field)
-              );
+                  castFrom<T>(data.fields[index], field)
+                );
 
             return {
               [enumShape.title]: args,
@@ -679,7 +701,7 @@ function castTo<T>(struct: Exact<T>, type: T): Data {
       const fields = shape.fields.map((field: Json) =>
         castTo<T>(
           (struct as Record<string, Json>)[field.title || "wrapper"],
-          field,
+          field
         )
       );
       return shape.hasConstr || shape.hasConstr === undefined
@@ -711,14 +733,14 @@ function castTo<T>(struct: Exact<T>, type: T): Data {
         case "string": {
           if (!/[A-Z]/.test(struct[0])) {
             throw new Error(
-              "Could not type cast to enum. Enum needs to start with an uppercase letter.",
+              "Could not type cast to enum. Enum needs to start with an uppercase letter."
             );
           }
           const enumIndex = (shape as TEnum).anyOf.findIndex(
             (s: TLiteral) =>
               s.dataType === "constructor" &&
               s.fields.length === 0 &&
-              s.title === struct,
+              s.title === struct
           );
           if (enumIndex === -1) throw new Error("Could not type cast to enum.");
           return new Constr(enumIndex, []);
@@ -729,12 +751,11 @@ function castTo<T>(struct: Exact<T>, type: T): Data {
 
           if (!/[A-Z]/.test(structTitle)) {
             throw new Error(
-              "Could not type cast to enum. Enum needs to start with an uppercase letter.",
+              "Could not type cast to enum. Enum needs to start with an uppercase letter."
             );
           }
           const enumEntry = shape.anyOf.find(
-            (s: Json) =>
-              s.dataType === "constructor" && s.title === structTitle,
+            (s: Json) => s.dataType === "constructor" && s.title === structTitle
           );
 
           if (!enumEntry) throw new Error("Could not type cast to enum.");
@@ -746,14 +767,14 @@ function castTo<T>(struct: Exact<T>, type: T): Data {
             // check if named args
             args instanceof Array
               ? args.map((item, index) =>
-                castTo<T>(item, enumEntry.fields[index])
-              )
+                  castTo<T>(item, enumEntry.fields[index])
+                )
               : enumEntry.fields.map((entry: Json) => {
-                const [_, item]: [string, Json] = Object.entries(args).find(
-                  ([title]) => title === entry.title,
-                )!;
-                return castTo<T>(item, entry);
-              }),
+                  const [_, item]: [string, Json] = Object.entries(args).find(
+                    ([title]) => title === entry.title
+                  )!;
+                  return castTo<T>(item, entry);
+                })
           );
         }
       }
@@ -798,22 +819,22 @@ function castTo<T>(struct: Exact<T>, type: T): Data {
 function integerConstraints(integer: bigint, shape: TSchema) {
   if (shape.minimum && integer < BigInt(shape.minimum)) {
     throw new Error(
-      `Integer ${integer} is below the minimum ${shape.minimum}.`,
+      `Integer ${integer} is below the minimum ${shape.minimum}.`
     );
   }
   if (shape.maximum && integer > BigInt(shape.maximum)) {
     throw new Error(
-      `Integer ${integer} is above the maxiumum ${shape.maximum}.`,
+      `Integer ${integer} is above the maxiumum ${shape.maximum}.`
     );
   }
   if (shape.exclusiveMinimum && integer <= BigInt(shape.exclusiveMinimum)) {
     throw new Error(
-      `Integer ${integer} is below the exclusive minimum ${shape.exclusiveMinimum}.`,
+      `Integer ${integer} is below the exclusive minimum ${shape.exclusiveMinimum}.`
     );
   }
   if (shape.exclusiveMaximum && integer >= BigInt(shape.exclusiveMaximum)) {
     throw new Error(
-      `Integer ${integer} is above the exclusive maximum ${shape.exclusiveMaximum}.`,
+      `Integer ${integer} is above the exclusive maximum ${shape.exclusiveMaximum}.`
     );
   }
 }
@@ -824,13 +845,13 @@ function bytesConstraints(bytes: string, shape: TSchema) {
   }
   if (shape.minLength && bytes.length / 2 < shape.minLength) {
     throw new Error(
-      `Bytes need to have a length of at least ${shape.minLength} bytes.`,
+      `Bytes need to have a length of at least ${shape.minLength} bytes.`
     );
   }
 
   if (shape.maxLength && bytes.length / 2 > shape.maxLength) {
     throw new Error(
-      `Bytes can have a length of at most ${shape.minLength} bytes.`,
+      `Bytes can have a length of at most ${shape.minLength} bytes.`
     );
   }
 }

--- a/src/plutus/data.ts
+++ b/src/plutus/data.ts
@@ -89,7 +89,7 @@ export const Data = {
   },
   Array: function <T extends TSchema>(
     items: T,
-    options?: { minItems?: number; maxItems?: number; uniqueItems?: boolean }
+    options?: { minItems?: number; maxItems?: number; uniqueItems?: boolean },
   ) {
     const array = Type.Array(items);
     replaceProperties(array, { dataType: "list", items });
@@ -103,7 +103,7 @@ export const Data = {
   Map: function <T extends TSchema, U extends TSchema>(
     keys: T,
     values: U,
-    options?: { minItems?: number; maxItems?: number }
+    options?: { minItems?: number; maxItems?: number },
   ) {
     const map = Type.Unsafe<Map<Data.Static<T>, Data.Static<U>>>({
       dataType: "map",
@@ -123,7 +123,7 @@ export const Data = {
    */
   Object: function <T extends TProperties>(
     properties: T,
-    options?: { hasConstr?: boolean }
+    options?: { hasConstr?: boolean },
   ) {
     const object = Type.Object(properties);
     replaceProperties(object, {
@@ -138,8 +138,8 @@ export const Data = {
         },
       ],
     });
-    object.anyOf[0].hasConstr =
-      typeof options?.hasConstr === "undefined" || options.hasConstr;
+    object.anyOf[0].hasConstr = typeof options?.hasConstr === "undefined" ||
+      options.hasConstr;
     return object;
   },
   Enum: function <T extends TSchema>(items: T[]) {
@@ -148,28 +148,27 @@ export const Data = {
       anyOf: items.map((item, index) =>
         item.anyOf[0].fields.length === 0
           ? {
-              ...item.anyOf[0],
-              index,
-            }
+            ...item.anyOf[0],
+            index,
+          }
           : {
-              dataType: "constructor",
-              title: (() => {
-                const title = item.anyOf[0].fields[0].title;
-                if (
-                  (title as string).charAt(0) !==
+            dataType: "constructor",
+            title: (() => {
+              const title = item.anyOf[0].fields[0].title;
+              if (
+                (title as string).charAt(0) !==
                   (title as string).charAt(0).toUpperCase()
-                ) {
-                  throw new Error(
-                    `Enum '${title}' needs to start with an uppercase letter.`
-                  );
-                }
-                return item.anyOf[0].fields[0].title;
-              })(),
-              index,
-              fields:
-                item.anyOf[0].fields[0].items ||
-                item.anyOf[0].fields[0].anyOf[0].fields,
-            }
+              ) {
+                throw new Error(
+                  `Enum '${title}' needs to start with an uppercase letter.`,
+                );
+              }
+              return item.anyOf[0].fields[0].title;
+            })(),
+            index,
+            fields: item.anyOf[0].fields[0].items ||
+              item.anyOf[0].fields[0].anyOf[0].fields,
+          }
       ),
     });
     return union;
@@ -180,7 +179,7 @@ export const Data = {
    */
   Tuple: function <T extends TSchema[]>(
     items: [...T],
-    options?: { hasConstr?: boolean }
+    options?: { hasConstr?: boolean },
   ) {
     const tuple = Type.Tuple(items);
     replaceProperties(tuple, {
@@ -199,7 +198,7 @@ export const Data = {
       (title as string).charAt(0) !== (title as string).charAt(0).toUpperCase()
     ) {
       throw new Error(
-        `Enum '${title}' needs to start with an uppercase letter.`
+        `Enum '${title}' needs to start with an uppercase letter.`,
       );
     }
     const literal = Type.Literal(title);
@@ -279,8 +278,8 @@ function to<T = Data>(data: Exact<T>, type?: T): Datum | Redeemer {
         return C.PlutusData.new_constr_plutus_data(
           C.ConstrPlutusData.new(
             C.BigNum.from_str(index.toString()),
-            plutusList
-          )
+            plutusList,
+          ),
         );
       } else if (data instanceof Array) {
         const plutusList = C.PlutusList.new();
@@ -409,14 +408,15 @@ function toJson(plutusData: Data): Json {
         !isNaN(parseInt(data)) &&
         data.slice(-1) === "n")
     ) {
-      const bigint =
-        typeof data === "string" ? BigInt(data.slice(0, -1)) : data;
+      const bigint = typeof data === "string"
+        ? BigInt(data.slice(0, -1))
+        : data;
       return parseInt(bigint.toString());
     }
     if (typeof data === "string") {
       try {
         return new TextDecoder(undefined, { fatal: true }).decode(
-          fromHex(data)
+          fromHex(data),
         );
       } catch (_) {
         return "0x" + toHex(fromHex(data));
@@ -432,7 +432,7 @@ function toJson(plutusData: Data): Json {
           typeof convertedKey !== "number"
         ) {
           throw new Error(
-            "Unsupported type (Note: Only bytes or integers can be keys of a JSON object)"
+            "Unsupported type (Note: Only bytes or integers can be keys of a JSON object)",
           );
         }
         tempJson[convertedKey] = fromData(value);
@@ -440,7 +440,7 @@ function toJson(plutusData: Data): Json {
       return tempJson;
     }
     throw new Error(
-      "Unsupported type (Note: Constructor cannot be converted to JSON)"
+      "Unsupported type (Note: Constructor cannot be converted to JSON)",
     );
   }
   return fromData(plutusData);
@@ -484,14 +484,14 @@ function castFrom<T = Data>(data: Data, type: T): T {
         const fields: Record<string, T> = {};
         if (shape.fields.length !== data.fields.length) {
           throw new Error(
-            "Could not type cast to object. Fields do not match."
+            "Could not type cast to object. Fields do not match.",
           );
         }
         shape.fields.forEach((field: Json, fieldIndex: number) => {
           const title = field.title || "wrapper";
           if (/[A-Z]/.test(title[0])) {
             throw new Error(
-              "Could not type cast to object. Object properties need to start with a lowercase letter."
+              "Could not type cast to object. Object properties need to start with a lowercase letter.",
             );
           }
           fields[title] = castFrom<T>(data.fields[fieldIndex], field);
@@ -510,7 +510,7 @@ function castFrom<T = Data>(data: Data, type: T): T {
           const title = field.title || "wrapper";
           if (/[A-Z]/.test(title[0])) {
             throw new Error(
-              "Could not type cast to object. Object properties need to start with a lowercase letter."
+              "Could not type cast to object. Object properties need to start with a lowercase letter.",
             );
           }
           fields[title] = castFrom<T>(data[fieldIndex], field);
@@ -530,7 +530,7 @@ function castFrom<T = Data>(data: Data, type: T): T {
       }
 
       const enumShape = shape.anyOf.find(
-        (entry: Json) => entry.index === data.index
+        (entry: Json) => entry.index === data.index,
       );
       if (!enumShape || enumShape.fields.length !== data.fields.length) {
         throw new Error("Could not type cast to enum.");
@@ -573,7 +573,7 @@ function castFrom<T = Data>(data: Data, type: T): T {
           } else {
             if (!/[A-Z]/.test(enumShape.title)) {
               throw new Error(
-                "Could not type cast to enum. Enums need to start with an uppercase letter."
+                "Could not type cast to enum. Enums need to start with an uppercase letter.",
               );
             }
 
@@ -584,14 +584,14 @@ function castFrom<T = Data>(data: Data, type: T): T {
             // check if named args
             const args = enumShape.fields[0].title
               ? Object.fromEntries(
-                  enumShape.fields.map((field: Json, index: number) => [
-                    field.title,
-                    castFrom<T>(data.fields[index], field),
-                  ])
-                )
+                enumShape.fields.map((field: Json, index: number) => [
+                  field.title,
+                  castFrom<T>(data.fields[index], field),
+                ]),
+              )
               : enumShape.fields.map((field: Json, index: number) =>
-                  castFrom<T>(data.fields[index], field)
-                );
+                castFrom<T>(data.fields[index], field)
+              );
 
             return {
               [enumShape.title]: args,
@@ -679,7 +679,7 @@ function castTo<T>(struct: Exact<T>, type: T): Data {
       const fields = shape.fields.map((field: Json) =>
         castTo<T>(
           (struct as Record<string, Json>)[field.title || "wrapper"],
-          field
+          field,
         )
       );
       return shape.hasConstr || shape.hasConstr === undefined
@@ -711,14 +711,14 @@ function castTo<T>(struct: Exact<T>, type: T): Data {
         case "string": {
           if (!/[A-Z]/.test(struct[0])) {
             throw new Error(
-              "Could not type cast to enum. Enum needs to start with an uppercase letter."
+              "Could not type cast to enum. Enum needs to start with an uppercase letter.",
             );
           }
           const enumIndex = (shape as TEnum).anyOf.findIndex(
             (s: TLiteral) =>
               s.dataType === "constructor" &&
               s.fields.length === 0 &&
-              s.title === struct
+              s.title === struct,
           );
           if (enumIndex === -1) throw new Error("Could not type cast to enum.");
           return new Constr(enumIndex, []);
@@ -729,11 +729,12 @@ function castTo<T>(struct: Exact<T>, type: T): Data {
 
           if (!/[A-Z]/.test(structTitle)) {
             throw new Error(
-              "Could not type cast to enum. Enum needs to start with an uppercase letter."
+              "Could not type cast to enum. Enum needs to start with an uppercase letter.",
             );
           }
           const enumEntry = shape.anyOf.find(
-            (s: Json) => s.dataType === "constructor" && s.title === structTitle
+            (s: Json) =>
+              s.dataType === "constructor" && s.title === structTitle,
           );
 
           if (!enumEntry) throw new Error("Could not type cast to enum.");
@@ -745,14 +746,14 @@ function castTo<T>(struct: Exact<T>, type: T): Data {
             // check if named args
             args instanceof Array
               ? args.map((item, index) =>
-                  castTo<T>(item, enumEntry.fields[index])
-                )
+                castTo<T>(item, enumEntry.fields[index])
+              )
               : enumEntry.fields.map((entry: Json) => {
-                  const [_, item]: [string, Json] = Object.entries(args).find(
-                    ([title]) => title === entry.title
-                  )!;
-                  return castTo<T>(item, entry);
-                })
+                const [_, item]: [string, Json] = Object.entries(args).find(
+                  ([title]) => title === entry.title,
+                )!;
+                return castTo<T>(item, entry);
+              }),
           );
         }
       }
@@ -797,38 +798,39 @@ function castTo<T>(struct: Exact<T>, type: T): Data {
 function integerConstraints(integer: bigint, shape: TSchema) {
   if (shape.minimum && integer < BigInt(shape.minimum)) {
     throw new Error(
-      `Integer ${integer} is below the minimum ${shape.minimum}.`
+      `Integer ${integer} is below the minimum ${shape.minimum}.`,
     );
   }
   if (shape.maximum && integer > BigInt(shape.maximum)) {
     throw new Error(
-      `Integer ${integer} is above the maxiumum ${shape.maximum}.`
+      `Integer ${integer} is above the maxiumum ${shape.maximum}.`,
     );
   }
   if (shape.exclusiveMinimum && integer <= BigInt(shape.exclusiveMinimum)) {
     throw new Error(
-      `Integer ${integer} is below the exclusive minimum ${shape.exclusiveMinimum}.`
+      `Integer ${integer} is below the exclusive minimum ${shape.exclusiveMinimum}.`,
     );
   }
   if (shape.exclusiveMaximum && integer >= BigInt(shape.exclusiveMaximum)) {
     throw new Error(
-      `Integer ${integer} is above the exclusive maximum ${shape.exclusiveMaximum}.`
+      `Integer ${integer} is above the exclusive maximum ${shape.exclusiveMaximum}.`,
     );
   }
 }
 
 function bytesConstraints(bytes: string, shape: TSchema) {
-  if (shape.enum && !shape.enum.some((keyword: string) => keyword === bytes))
+  if (shape.enum && !shape.enum.some((keyword: string) => keyword === bytes)) {
     throw new Error(`None of the keywords match with '${bytes}'.`);
+  }
   if (shape.minLength && bytes.length / 2 < shape.minLength) {
     throw new Error(
-      `Bytes need to have a length of at least ${shape.minLength} bytes.`
+      `Bytes need to have a length of at least ${shape.minLength} bytes.`,
     );
   }
 
   if (shape.maxLength && bytes.length / 2 > shape.maxLength) {
     throw new Error(
-      `Bytes can have a length of at most ${shape.minLength} bytes.`
+      `Bytes can have a length of at most ${shape.minLength} bytes.`,
     );
   }
 }

--- a/src/plutus/data.ts
+++ b/src/plutus/data.ts
@@ -89,7 +89,7 @@ export const Data = {
   },
   Array: function <T extends TSchema>(
     items: T,
-    options?: { minItems?: number; maxItems?: number; uniqueItems?: boolean }
+    options?: { minItems?: number; maxItems?: number; uniqueItems?: boolean },
   ) {
     const array = Type.Array(items);
     replaceProperties(array, { dataType: "list", items });
@@ -103,7 +103,7 @@ export const Data = {
   Map: function <T extends TSchema, U extends TSchema>(
     keys: T,
     values: U,
-    options?: { minItems?: number; maxItems?: number }
+    options?: { minItems?: number; maxItems?: number },
   ) {
     const map = Type.Unsafe<Map<Data.Static<T>, Data.Static<U>>>({
       dataType: "map",
@@ -123,7 +123,7 @@ export const Data = {
    */
   Object: function <T extends TProperties>(
     properties: T,
-    options?: { hasConstr?: boolean }
+    options?: { hasConstr?: boolean },
   ) {
     const object = Type.Object(properties);
     replaceProperties(object, {
@@ -138,8 +138,8 @@ export const Data = {
         },
       ],
     });
-    object.anyOf[0].hasConstr =
-      typeof options?.hasConstr === "undefined" || options.hasConstr;
+    object.anyOf[0].hasConstr = typeof options?.hasConstr === "undefined" ||
+      options.hasConstr;
     return object;
   },
   Enum: function <T extends TSchema>(items: T[]) {
@@ -148,28 +148,27 @@ export const Data = {
       anyOf: items.map((item, index) =>
         item.anyOf[0].fields.length === 0
           ? {
-              ...item.anyOf[0],
-              index,
-            }
+            ...item.anyOf[0],
+            index,
+          }
           : {
-              dataType: "constructor",
-              title: (() => {
-                const title = item.anyOf[0].fields[0].title;
-                if (
-                  (title as string).charAt(0) !==
+            dataType: "constructor",
+            title: (() => {
+              const title = item.anyOf[0].fields[0].title;
+              if (
+                (title as string).charAt(0) !==
                   (title as string).charAt(0).toUpperCase()
-                ) {
-                  throw new Error(
-                    `Enum '${title}' needs to start with an uppercase letter.`
-                  );
-                }
-                return item.anyOf[0].fields[0].title;
-              })(),
-              index,
-              fields:
-                item.anyOf[0].fields[0].items ||
-                item.anyOf[0].fields[0].anyOf[0].fields,
-            }
+              ) {
+                throw new Error(
+                  `Enum '${title}' needs to start with an uppercase letter.`,
+                );
+              }
+              return item.anyOf[0].fields[0].title;
+            })(),
+            index,
+            fields: item.anyOf[0].fields[0].items ||
+              item.anyOf[0].fields[0].anyOf[0].fields,
+          }
       ),
     });
     return union;
@@ -180,7 +179,7 @@ export const Data = {
    */
   Tuple: function <T extends TSchema[]>(
     items: [...T],
-    options?: { hasConstr?: boolean }
+    options?: { hasConstr?: boolean },
   ) {
     const tuple = Type.Tuple(items);
     replaceProperties(tuple, {
@@ -199,7 +198,7 @@ export const Data = {
       (title as string).charAt(0) !== (title as string).charAt(0).toUpperCase()
     ) {
       throw new Error(
-        `Enum '${title}' needs to start with an uppercase letter.`
+        `Enum '${title}' needs to start with an uppercase letter.`,
       );
     }
     const literal = Type.Literal(title);
@@ -279,8 +278,8 @@ function to<T = Data>(data: Exact<T>, type?: T): Datum | Redeemer {
         return C.PlutusData.new_constr_plutus_data(
           C.ConstrPlutusData.new(
             C.BigNum.from_str(index.toString()),
-            plutusList
-          )
+            plutusList,
+          ),
         );
       } else if (data instanceof Array) {
         const plutusList = C.PlutusList.new();
@@ -409,14 +408,15 @@ function toJson(plutusData: Data): Json {
         !isNaN(parseInt(data)) &&
         data.slice(-1) === "n")
     ) {
-      const bigint =
-        typeof data === "string" ? BigInt(data.slice(0, -1)) : data;
+      const bigint = typeof data === "string"
+        ? BigInt(data.slice(0, -1))
+        : data;
       return parseInt(bigint.toString());
     }
     if (typeof data === "string") {
       try {
         return new TextDecoder(undefined, { fatal: true }).decode(
-          fromHex(data)
+          fromHex(data),
         );
       } catch (_) {
         return "0x" + toHex(fromHex(data));
@@ -432,7 +432,7 @@ function toJson(plutusData: Data): Json {
           typeof convertedKey !== "number"
         ) {
           throw new Error(
-            "Unsupported type (Note: Only bytes or integers can be keys of a JSON object)"
+            "Unsupported type (Note: Only bytes or integers can be keys of a JSON object)",
           );
         }
         tempJson[convertedKey] = fromData(value);
@@ -440,7 +440,7 @@ function toJson(plutusData: Data): Json {
       return tempJson;
     }
     throw new Error(
-      "Unsupported type (Note: Constructor cannot be converted to JSON)"
+      "Unsupported type (Note: Constructor cannot be converted to JSON)",
     );
   }
   return fromData(plutusData);
@@ -484,14 +484,14 @@ function castFrom<T = Data>(data: Data, type: T): T {
         const fields: Record<string, T> = {};
         if (shape.fields.length !== data.fields.length) {
           throw new Error(
-            "Could not type cast to object. Fields do not match."
+            "Could not type cast to object. Fields do not match.",
           );
         }
         shape.fields.forEach((field: Json, fieldIndex: number) => {
           const title = field.title || "wrapper";
           if (/[A-Z]/.test(title[0])) {
             throw new Error(
-              "Could not type cast to object. Object properties need to start with a lowercase letter."
+              "Could not type cast to object. Object properties need to start with a lowercase letter.",
             );
           }
           fields[title] = castFrom<T>(data.fields[fieldIndex], field);
@@ -510,7 +510,7 @@ function castFrom<T = Data>(data: Data, type: T): T {
           const title = field.title || "wrapper";
           if (/[A-Z]/.test(title[0])) {
             throw new Error(
-              "Could not type cast to object. Object properties need to start with a lowercase letter."
+              "Could not type cast to object. Object properties need to start with a lowercase letter.",
             );
           }
           fields[title] = castFrom<T>(data[fieldIndex], field);
@@ -530,7 +530,7 @@ function castFrom<T = Data>(data: Data, type: T): T {
       }
 
       const enumShape = shape.anyOf.find(
-        (entry: Json) => entry.index === data.index
+        (entry: Json) => entry.index === data.index,
       );
       if (!enumShape || enumShape.fields.length !== data.fields.length) {
         throw new Error("Could not type cast to enum.");
@@ -573,7 +573,7 @@ function castFrom<T = Data>(data: Data, type: T): T {
           } else {
             if (!/[A-Z]/.test(enumShape.title)) {
               throw new Error(
-                "Could not type cast to enum. Enums need to start with an uppercase letter."
+                "Could not type cast to enum. Enums need to start with an uppercase letter.",
               );
             }
 
@@ -584,14 +584,14 @@ function castFrom<T = Data>(data: Data, type: T): T {
             // check if named args
             const args = enumShape.fields[0].title
               ? Object.fromEntries(
-                  enumShape.fields.map((field: Json, index: number) => [
-                    field.title,
-                    castFrom<T>(data.fields[index], field),
-                  ])
-                )
+                enumShape.fields.map((field: Json, index: number) => [
+                  field.title,
+                  castFrom<T>(data.fields[index], field),
+                ]),
+              )
               : enumShape.fields.map((field: Json, index: number) =>
-                  castFrom<T>(data.fields[index], field)
-                );
+                castFrom<T>(data.fields[index], field)
+              );
 
             return {
               [enumShape.title]: args,
@@ -679,7 +679,7 @@ function castTo<T>(struct: Exact<T>, type: T): Data {
       const fields = shape.fields.map((field: Json) =>
         castTo<T>(
           (struct as Record<string, Json>)[field.title || "wrapper"],
-          field
+          field,
         )
       );
       return shape.hasConstr || shape.hasConstr === undefined
@@ -711,14 +711,14 @@ function castTo<T>(struct: Exact<T>, type: T): Data {
         case "string": {
           if (!/[A-Z]/.test(struct[0])) {
             throw new Error(
-              "Could not type cast to enum. Enum needs to start with an uppercase letter."
+              "Could not type cast to enum. Enum needs to start with an uppercase letter.",
             );
           }
           const enumIndex = (shape as TEnum).anyOf.findIndex(
             (s: TLiteral) =>
               s.dataType === "constructor" &&
               s.fields.length === 0 &&
-              s.title === struct
+              s.title === struct,
           );
           if (enumIndex === -1) throw new Error("Could not type cast to enum.");
           return new Constr(enumIndex, []);
@@ -729,11 +729,12 @@ function castTo<T>(struct: Exact<T>, type: T): Data {
 
           if (!/[A-Z]/.test(structTitle)) {
             throw new Error(
-              "Could not type cast to enum. Enum needs to start with an uppercase letter."
+              "Could not type cast to enum. Enum needs to start with an uppercase letter.",
             );
           }
           const enumEntry = shape.anyOf.find(
-            (s: Json) => s.dataType === "constructor" && s.title === structTitle
+            (s: Json) =>
+              s.dataType === "constructor" && s.title === structTitle,
           );
 
           if (!enumEntry) throw new Error("Could not type cast to enum.");
@@ -745,14 +746,14 @@ function castTo<T>(struct: Exact<T>, type: T): Data {
             // check if named args
             args instanceof Array
               ? args.map((item, index) =>
-                  castTo<T>(item, enumEntry.fields[index])
-                )
+                castTo<T>(item, enumEntry.fields[index])
+              )
               : enumEntry.fields.map((entry: Json) => {
-                  const [_, item]: [string, Json] = Object.entries(args).find(
-                    ([title]) => title === entry.title
-                  )!;
-                  return castTo<T>(item, entry);
-                })
+                const [_, item]: [string, Json] = Object.entries(args).find(
+                  ([title]) => title === entry.title,
+                )!;
+                return castTo<T>(item, entry);
+              }),
           );
         }
       }
@@ -797,22 +798,22 @@ function castTo<T>(struct: Exact<T>, type: T): Data {
 function integerConstraints(integer: bigint, shape: TSchema) {
   if (shape.minimum && integer < BigInt(shape.minimum)) {
     throw new Error(
-      `Integer ${integer} is below the minimum ${shape.minimum}.`
+      `Integer ${integer} is below the minimum ${shape.minimum}.`,
     );
   }
   if (shape.maximum && integer > BigInt(shape.maximum)) {
     throw new Error(
-      `Integer ${integer} is above the maxiumum ${shape.maximum}.`
+      `Integer ${integer} is above the maxiumum ${shape.maximum}.`,
     );
   }
   if (shape.exclusiveMinimum && integer <= BigInt(shape.exclusiveMinimum)) {
     throw new Error(
-      `Integer ${integer} is below the exclusive minimum ${shape.exclusiveMinimum}.`
+      `Integer ${integer} is below the exclusive minimum ${shape.exclusiveMinimum}.`,
     );
   }
   if (shape.exclusiveMaximum && integer >= BigInt(shape.exclusiveMaximum)) {
     throw new Error(
-      `Integer ${integer} is above the exclusive maximum ${shape.exclusiveMaximum}.`
+      `Integer ${integer} is above the exclusive maximum ${shape.exclusiveMaximum}.`,
     );
   }
 }
@@ -823,13 +824,13 @@ function bytesConstraints(bytes: string, shape: TSchema) {
   }
   if (shape.minLength && bytes.length / 2 < shape.minLength) {
     throw new Error(
-      `Bytes need to have a length of at least ${shape.minLength} bytes.`
+      `Bytes need to have a length of at least ${shape.minLength} bytes.`,
     );
   }
 
   if (shape.maxLength && bytes.length / 2 > shape.maxLength) {
     throw new Error(
-      `Bytes can have a length of at most ${shape.minLength} bytes.`
+      `Bytes can have a length of at most ${shape.minLength} bytes.`,
     );
   }
 }

--- a/src/provider/blockfrost.ts
+++ b/src/provider/blockfrost.ts
@@ -90,14 +90,13 @@ export class Blockfrost implements Provider {
   ): Promise<UTxO[]> {
     const queryPredicate = (() => {
       if (typeof addressOrCredential === "string") return addressOrCredential;
-      const credentialBech32 =
+      const hash =
         addressOrCredential.type === "Key"
-          ? C.Ed25519KeyHash.from_hex(addressOrCredential.hash).to_bech32(
-              "addr_vkh"
-            )
-          : C.ScriptHash.from_hex(addressOrCredential.hash).to_bech32(
-              "addr_vkh"
-            ); // should be 'script' (CIP-0005)
+          ? C.Ed25519KeyHash.from_hex(addressOrCredential.hash)
+          : C.ScriptHash.from_hex(addressOrCredential.hash);
+
+      const credentialBech32 = hash.to_bech32("addr_vkh"); // should be 'script' according to CIP-0005, but to maintain bakcwards compatabiltiy I am not changing this
+      hash.free();
       return credentialBech32;
     })();
     let result: BlockfrostUtxoResult = [];

--- a/src/provider/emulator.ts
+++ b/src/provider/emulator.ts
@@ -20,6 +20,7 @@ import {
   UnixTime,
   UTxO,
 } from "../types/types.ts";
+import { FreeableBucket } from "../utils/freeable.ts";
 import { PROTOCOL_PARAMETERS_DEFAULT } from "../utils/mod.ts";
 import {
   coreToUtxo,
@@ -54,7 +55,7 @@ export class Emulator implements Provider {
       assets: Assets;
       outputData?: OutputData;
     }[],
-    protocolParameters: ProtocolParameters = PROTOCOL_PARAMETERS_DEFAULT,
+    protocolParameters: ProtocolParameters = PROTOCOL_PARAMETERS_DEFAULT
   ) {
     const GENESIS_HASH = "00".repeat(32);
     this.blockHeight = 0;
@@ -63,15 +64,12 @@ export class Emulator implements Provider {
     this.ledger = {};
     accounts.forEach(({ address, assets, outputData }, index) => {
       if (
-        [
-          outputData?.hash,
-          outputData?.asHash,
-          outputData?.inline,
-        ].filter((b) => b)
-          .length > 1
+        [outputData?.hash, outputData?.asHash, outputData?.inline].filter(
+          (b) => b
+        ).length > 1
       ) {
         throw new Error(
-          "Not allowed to set hash, asHash and inline at the same time.",
+          "Not allowed to set hash, asHash and inline at the same time."
         );
       }
 
@@ -83,8 +81,8 @@ export class Emulator implements Provider {
           assets,
           datumHash: outputData?.asHash
             ? C.hash_plutus_data(
-              C.PlutusData.from_bytes(fromHex(outputData.asHash)),
-            ).to_hex()
+                C.PlutusData.from_bytes(fromHex(outputData.asHash))
+              ).to_hex()
             : outputData?.hash,
           datum: outputData?.inline,
           scriptRef: outputData?.scriptRef,
@@ -139,16 +137,12 @@ export class Emulator implements Provider {
       if (typeof addressOrCredential === "string") {
         return addressOrCredential === utxo.address ? utxo : [];
       } else {
-        const { paymentCredential } = getAddressDetails(
-          utxo.address,
-        );
+        const { paymentCredential } = getAddressDetails(utxo.address);
         return paymentCredential?.hash === addressOrCredential.hash ? utxo : [];
       }
     });
 
-    return Promise.resolve(
-      utxos,
-    );
+    return Promise.resolve(utxos);
   }
 
   getProtocolParameters(): Promise<ProtocolParameters> {
@@ -161,7 +155,7 @@ export class Emulator implements Provider {
 
   getUtxosWithUnit(
     addressOrCredential: Address | Credential,
-    unit: Unit,
+    unit: Unit
   ): Promise<UTxO[]> {
     const utxos: UTxO[] = Object.values(this.ledger).flatMap(({ utxo }) => {
       if (typeof addressOrCredential === "string") {
@@ -169,26 +163,22 @@ export class Emulator implements Provider {
           ? utxo
           : [];
       } else {
-        const { paymentCredential } = getAddressDetails(
-          utxo.address,
-        );
+        const { paymentCredential } = getAddressDetails(utxo.address);
         return paymentCredential?.hash === addressOrCredential.hash &&
-            utxo.assets[unit] > 0n
+          utxo.assets[unit] > 0n
           ? utxo
           : [];
       }
     });
 
-    return Promise.resolve(
-      utxos,
-    );
+    return Promise.resolve(utxos);
   }
 
   getUtxosByOutRef(outRefs: OutRef[]): Promise<UTxO[]> {
     return Promise.resolve(
-      outRefs.flatMap((outRef) =>
-        this.ledger[outRef.txHash + outRef.outputIndex]?.utxo || []
-      ),
+      outRefs.flatMap(
+        (outRef) => this.ledger[outRef.txHash + outRef.outputIndex]?.utxo || []
+      )
     );
   }
 
@@ -224,17 +214,16 @@ export class Emulator implements Provider {
    * Stake keys need to be registered and delegated like on a real chain in order to receive rewards.
    */
   distributeRewards(rewards: Lovelace) {
-    for (
-      const [rewardAddress, { registeredStake, delegation }] of Object.entries(
-        this.chain,
-      )
-    ) {
+    for (const [
+      rewardAddress,
+      { registeredStake, delegation },
+    ] of Object.entries(this.chain)) {
       if (registeredStake && delegation.poolId) {
         this.chain[rewardAddress] = {
           registeredStake,
           delegation: {
             poolId: delegation.poolId,
-            rewards: delegation.rewards += rewards,
+            rewards: (delegation.rewards += rewards),
           },
         };
       }
@@ -260,31 +249,42 @@ export class Emulator implements Provider {
           - Validity interval
      */
 
+    const bucket: FreeableBucket = [];
     const desTx = C.Transaction.from_bytes(fromHex(tx));
+    bucket.push(desTx);
 
     const body = desTx.body();
+    bucket.push(body);
     const witnesses = desTx.witness_set();
+    bucket.push(witnesses);
     const datums = witnesses.plutus_data();
+    bucket.push(datums);
 
-    const txHash = C.hash_transaction(body).to_hex();
+    const transactionHash = C.hash_transaction(body);
+    bucket.push(transactionHash);
+    const txHash = transactionHash.to_hex();
 
     // Validity interval
     // Lower bound is inclusive?
     // Upper bound is inclusive?
-    const lowerBound = body.validity_start_interval()
-      ? parseInt(body.validity_start_interval()!.to_str())
+    const validityStartInterval = body.validity_start_interval();
+    bucket.push(validityStartInterval);
+    const lowerBound = validityStartInterval
+      ? parseInt(validityStartInterval.to_str())
       : null;
-    const upperBound = body.ttl() ? parseInt(body.ttl()!.to_str()) : null;
+    const ttl = body.ttl();
+    bucket.push(ttl);
+    const upperBound = ttl ? parseInt(ttl.to_str()) : null;
 
     if (Number.isInteger(lowerBound) && this.slot < lowerBound!) {
       throw new Error(
-        `Lower bound (${lowerBound}) not in slot range (${this.slot}).`,
+        `Lower bound (${lowerBound}) not in slot range (${this.slot}).`
       );
     }
 
     if (Number.isInteger(upperBound) && this.slot > upperBound!) {
       throw new Error(
-        `Upper bound (${upperBound}) not in slot range (${this.slot}).`,
+        `Upper bound (${upperBound}) not in slot range (${this.slot}).`
       );
     }
 
@@ -293,7 +293,10 @@ export class Emulator implements Provider {
       const table: Record<DatumHash, Datum> = {};
       for (let i = 0; i < (datums?.len() || 0); i++) {
         const datum = datums!.get(i);
-        const datumHash = C.hash_plutus_data(datum).to_hex();
+        bucket.push(datum);
+        const plutusDataHash = C.hash_plutus_data(datum);
+        bucket.push(plutusDataHash);
+        const datumHash = plutusDataHash.to_hex();
         table[datumHash] = toHex(datum.to_bytes());
       }
       return table;
@@ -304,15 +307,21 @@ export class Emulator implements Provider {
     // Witness keys
     const keyHashes = (() => {
       const keyHashes = [];
-      for (let i = 0; i < (witnesses.vkeys()?.len() || 0); i++) {
-        const witness = witnesses.vkeys()!.get(i);
-        const publicKey = witness.vkey().public_key();
-        const keyHash = publicKey.hash().to_hex();
+      const vkeys = witnesses.vkeys();
+      bucket.push(vkeys);
+      for (let i = 0; i < (vkeys?.len() || 0); i++) {
+        const witness = vkeys!.get(i);
+        bucket.push(witness);
+        const vkey = witness.vkey();
+        bucket.push(vkey);
+        const publicKey = vkey.public_key();
+        bucket.push(publicKey);
+        const hash = publicKey.hash();
+        bucket.push(hash);
+        const keyHash = hash.to_hex();
 
         if (!publicKey.verify(fromHex(txHash), witness.signature())) {
-          throw new Error(
-            `Invalid vkey witness. Key hash: ${keyHash}`,
-          );
+          throw new Error(`Invalid vkey witness. Key hash: ${keyHash}`);
         }
         keyHashes.push(keyHash);
       }
@@ -321,35 +330,43 @@ export class Emulator implements Provider {
 
     // We only need this to verify native scripts. The check happens in the CML.
     const edKeyHashes = C.Ed25519KeyHashes.new();
-    keyHashes.forEach((keyHash) =>
-      edKeyHashes.add(C.Ed25519KeyHash.from_hex(keyHash))
-    );
+    bucket.push(edKeyHashes);
+    keyHashes.forEach((keyHash) => {
+      const ed25519KeyHash = C.Ed25519KeyHash.from_hex(keyHash);
+      bucket.push(ed25519KeyHash);
+      edKeyHashes.add(ed25519KeyHash);
+    });
 
     const nativeHashes = (() => {
       const scriptHashes = [];
+      const nativeScripts = witnesses.native_scripts();
+      bucket.push(nativeScripts);
+      for (let i = 0; i < (nativeScripts?.len() || 0); i++) {
+        const witness = nativeScripts!.get(i);
+        bucket.push(witness);
+        const hash = witness.hash(C.ScriptHashNamespace.NativeScript);
+        bucket.push(hash);
+        const scriptHash = hash.to_hex();
 
-      for (let i = 0; i < (witnesses.native_scripts()?.len() || 0); i++) {
-        const witness = witnesses.native_scripts()!.get(i);
-        const scriptHash = witness.hash(C.ScriptHashNamespace.NativeScript)
-          .to_hex();
-
-        if (
-          !witness.verify(
-            Number.isInteger(lowerBound)
-              ? C.BigNum.from_str(lowerBound!.toString())
-              : undefined,
-            Number.isInteger(upperBound)
-              ? C.BigNum.from_str(upperBound!.toString())
-              : undefined,
-            edKeyHashes,
-          )
-        ) {
+        const lBound = Number.isInteger(lowerBound)
+          ? C.BigNum.from_str(lowerBound!.toString())
+          : undefined;
+        bucket.push(lBound);
+        const uBound = Number.isInteger(upperBound)
+          ? C.BigNum.from_str(upperBound!.toString())
+          : undefined;
+        bucket.push(uBound);
+        if (!witness.verify(lBound, uBound, edKeyHashes)) {
           throw new Error(
-            `Invalid native script witness. Script hash: ${scriptHash}`,
+            `Invalid native script witness. Script hash: ${scriptHash}`
           );
         }
-        for (let i = 0; i < witness.get_required_signers().len(); i++) {
-          const keyHash = witness.get_required_signers().get(i).to_hex();
+        const requiredSigners = witness.get_required_signers();
+        bucket.push(requiredSigners);
+        for (let i = 0; i < requiredSigners.len(); i++) {
+          const hash = requiredSigners.get(i);
+          bucket.push(hash);
+          const keyHash = hash.to_hex();
           consumedHashes.add(keyHash);
         }
         scriptHashes.push(scriptHash);
@@ -362,17 +379,26 @@ export class Emulator implements Provider {
 
     const plutusHashes = (() => {
       const scriptHashes = [];
-      for (let i = 0; i < (witnesses.plutus_scripts()?.len() || 0); i++) {
-        const script = witnesses.plutus_scripts()!.get(i);
-        const scriptHash = script.hash(C.ScriptHashNamespace.PlutusV1)
-          .to_hex();
+      const plutusScripts = witnesses.plutus_scripts();
+      bucket.push(plutusScripts);
+      for (let i = 0; i < (plutusScripts?.len() || 0); i++) {
+        const script = plutusScripts!.get(i);
+        bucket.push(script);
+        const hash = script.hash(C.ScriptHashNamespace.PlutusV1);
+        bucket.push(hash);
+        const scriptHash = hash.to_hex();
 
         scriptHashes.push(scriptHash);
       }
-      for (let i = 0; i < (witnesses.plutus_v2_scripts()?.len() || 0); i++) {
-        const script = witnesses.plutus_v2_scripts()!.get(i);
-        const scriptHash = script.hash(C.ScriptHashNamespace.PlutusV2)
-          .to_hex();
+
+      const plutusV2Scripts = witnesses.plutus_v2_scripts();
+      bucket.push(plutusV2Scripts);
+      for (let i = 0; i < (plutusV2Scripts?.len() || 0); i++) {
+        const script = plutusV2Scripts!.get(i);
+        bucket.push(script);
+        const hash = script.hash(C.ScriptHashNamespace.PlutusV2);
+        bucket.push(hash);
+        const scriptHash = hash.to_hex();
 
         scriptHashes.push(scriptHash);
       }
@@ -380,6 +406,7 @@ export class Emulator implements Provider {
     })();
 
     const inputs = body.inputs();
+    bucket.push(inputs);
     inputs.sort();
 
     type ResolvedInput = {
@@ -392,8 +419,13 @@ export class Emulator implements Provider {
     // Check existence of inputs and look for script refs.
     for (let i = 0; i < inputs.len(); i++) {
       const input = inputs.get(i);
+      bucket.push(input);
+      const transactionId = input.transaction_id();
+      bucket.push(transactionId);
+      const transactionIndex = input.index();
+      bucket.push(transactionIndex);
 
-      const outRef = input.transaction_id().to_hex() + input.index().to_str();
+      const outRef = transactionId.to_hex() + transactionIndex.to_str();
 
       const entryLedger = this.ledger[outRef];
 
@@ -403,12 +435,10 @@ export class Emulator implements Provider {
 
       if (!entry || entry.spent) {
         throw new Error(
-          `Could not spend UTxO: ${
-            JSON.stringify({
-              txHash: entry?.utxo.txHash,
-              outputIndex: entry?.utxo.outputIndex,
-            })
-          }\nIt does not exist or was already spent.`,
+          `Could not spend UTxO: ${JSON.stringify({
+            txHash: entry?.utxo.txHash,
+            outputIndex: entry?.utxo.outputIndex,
+          })}\nIt does not exist or was already spent.`
         );
       }
 
@@ -417,23 +447,27 @@ export class Emulator implements Provider {
         switch (scriptRef.type) {
           case "Native": {
             const script = C.NativeScript.from_bytes(fromHex(scriptRef.script));
-            nativeHashesOptional[
-              script.hash(C.ScriptHashNamespace.NativeScript).to_hex()
-            ] = script;
+            bucket.push(script);
+            const hash = script.hash(C.ScriptHashNamespace.NativeScript);
+            bucket.push(hash);
+
+            nativeHashesOptional[hash.to_hex()] = script;
             break;
           }
           case "PlutusV1": {
             const script = C.PlutusScript.from_bytes(fromHex(scriptRef.script));
-            plutusHashesOptional.push(
-              script.hash(C.ScriptHashNamespace.PlutusV1).to_hex(),
-            );
+            bucket.push(script);
+            const hash = script.hash(C.ScriptHashNamespace.PlutusV1);
+            bucket.push(hash);
+            plutusHashesOptional.push(hash.to_hex());
             break;
           }
           case "PlutusV2": {
             const script = C.PlutusScript.from_bytes(fromHex(scriptRef.script));
-            plutusHashesOptional.push(
-              script.hash(C.ScriptHashNamespace.PlutusV2).to_hex(),
-            );
+            bucket.push(script);
+            const hash = script.hash(C.ScriptHashNamespace.PlutusV2);
+            bucket.push(hash);
+            plutusHashesOptional.push(hash.to_hex());
             break;
           }
         }
@@ -445,21 +479,27 @@ export class Emulator implements Provider {
     }
 
     // Check existence of reference inputs and look for script refs.
-    for (let i = 0; i < (body.reference_inputs()?.len() || 0); i++) {
-      const input = body.reference_inputs()!.get(i);
+    const referenceInputs = body.reference_inputs();
+    bucket.push(referenceInputs);
+    for (let i = 0; i < (referenceInputs?.len() || 0); i++) {
+      const input = referenceInputs!.get(i);
+      bucket.push(input);
 
-      const outRef = input.transaction_id().to_hex() + input.index().to_str();
+      const inputId = input.transaction_id();
+      bucket.push(inputId);
+      const inputIndex = input.index();
+      bucket.push(inputIndex);
+
+      const outRef = inputId.to_hex() + inputIndex.to_str();
 
       const entry = this.ledger[outRef] || this.mempool[outRef];
 
       if (!entry || entry.spent) {
         throw new Error(
-          `Could not read UTxO: ${
-            JSON.stringify({
-              txHash: entry?.utxo.txHash,
-              outputIndex: entry?.utxo.outputIndex,
-            })
-          }\nIt does not exist or was already spent.`,
+          `Could not read UTxO: ${JSON.stringify({
+            txHash: entry?.utxo.txHash,
+            outputIndex: entry?.utxo.outputIndex,
+          })}\nIt does not exist or was already spent.`
         );
       }
 
@@ -468,23 +508,27 @@ export class Emulator implements Provider {
         switch (scriptRef.type) {
           case "Native": {
             const script = C.NativeScript.from_bytes(fromHex(scriptRef.script));
-            nativeHashesOptional[
-              script.hash(C.ScriptHashNamespace.NativeScript).to_hex()
-            ] = script;
+            bucket.push(script);
+            const hash = script.hash(C.ScriptHashNamespace.NativeScript);
+            bucket.push(hash);
+
+            nativeHashesOptional[hash.to_hex()] = script;
             break;
           }
           case "PlutusV1": {
             const script = C.PlutusScript.from_bytes(fromHex(scriptRef.script));
-            plutusHashesOptional.push(
-              script.hash(C.ScriptHashNamespace.PlutusV1).to_hex(),
-            );
+            bucket.push(script);
+            const hash = script.hash(C.ScriptHashNamespace.PlutusV1);
+            bucket.push(hash);
+            plutusHashesOptional.push(hash.to_hex());
             break;
           }
           case "PlutusV2": {
             const script = C.PlutusScript.from_bytes(fromHex(scriptRef.script));
-            plutusHashesOptional.push(
-              script.hash(C.ScriptHashNamespace.PlutusV2).to_hex(),
-            );
+            bucket.push(script);
+            const hash = script.hash(C.ScriptHashNamespace.PlutusV2);
+            bucket.push(hash);
+            plutusHashesOptional.push(hash.to_hex());
             break;
           }
         }
@@ -503,11 +547,19 @@ export class Emulator implements Provider {
         3: "Reward",
       };
       const collected = [];
-      for (let i = 0; i < (witnesses.redeemers()?.len() || 0); i++) {
-        const redeemer = witnesses.redeemers()!.get(i);
+      const redeemers = witnesses.redeemers();
+      bucket.push(redeemers);
+      for (let i = 0; i < (redeemers?.len() || 0); i++) {
+        const redeemer = redeemers!.get(i);
+        bucket.push(redeemer);
+        const tag = redeemer.tag();
+        bucket.push(tag);
+
+        const redeemerIndex = redeemer.index();
+        bucket.push(redeemerIndex);
         collected.push({
-          tag: tagMap[redeemer.tag().kind()],
-          index: parseInt(redeemer.index().to_str()),
+          tag: tagMap[tag.kind()],
+          index: parseInt(redeemerIndex.to_str()),
         });
       }
       return collected;
@@ -516,13 +568,13 @@ export class Emulator implements Provider {
     function checkAndConsumeHash(
       credential: Credential,
       tag: Tag | null,
-      index: number | null,
+      index: number | null
     ) {
       switch (credential.type) {
         case "Key": {
           if (!keyHashes.includes(credential.hash)) {
             throw new Error(
-              `Missing vkey witness. Key hash: ${credential.hash}`,
+              `Missing vkey witness. Key hash: ${credential.hash}`
             );
           }
           consumedHashes.add(credential.hash);
@@ -533,19 +585,24 @@ export class Emulator implements Provider {
             consumedHashes.add(credential.hash);
             break;
           } else if (nativeHashesOptional[credential.hash]) {
+            const lBound = Number.isInteger(lowerBound)
+              ? C.BigNum.from_str(lowerBound!.toString())
+              : undefined;
+            bucket.push(lBound);
+            const uBound = Number.isInteger(upperBound)
+              ? C.BigNum.from_str(upperBound!.toString())
+              : undefined;
+            bucket.push(uBound);
+
             if (
               !nativeHashesOptional[credential.hash].verify(
-                Number.isInteger(lowerBound)
-                  ? C.BigNum.from_str(lowerBound!.toString())
-                  : undefined,
-                Number.isInteger(upperBound)
-                  ? C.BigNum.from_str(upperBound!.toString())
-                  : undefined,
-                edKeyHashes,
+                lBound,
+                uBound,
+                edKeyHashes
               )
             ) {
               throw new Error(
-                `Invalid native script witness. Script hash: ${credential.hash}`,
+                `Invalid native script witness. Script hash: ${credential.hash}`
               );
             }
             break;
@@ -554,8 +611,8 @@ export class Emulator implements Provider {
             plutusHashesOptional.includes(credential.hash)
           ) {
             if (
-              redeemers.find((redeemer) =>
-                redeemer.tag === tag && redeemer.index === index
+              redeemers.find(
+                (redeemer) => redeemer.tag === tag && redeemer.index === index
               )
             ) {
               consumedHashes.add(credential.hash);
@@ -563,29 +620,34 @@ export class Emulator implements Provider {
             }
           }
           throw new Error(
-            `Missing script witness. Script hash: ${credential.hash}`,
+            `Missing script witness. Script hash: ${credential.hash}`
           );
         }
       }
     }
 
     // Check collateral inputs
+    const collateral = body.collateral();
+    bucket.push(collateral);
+    for (let i = 0; i < (collateral?.len() || 0); i++) {
+      const input = collateral!.get(i);
+      bucket.push(input);
 
-    for (let i = 0; i < (body.collateral()?.len() || 0); i++) {
-      const input = body.collateral()!.get(i);
+      const transactionId = input.transaction_id();
+      bucket.push(transactionId);
+      const transactionIndex = input.index();
+      bucket.push(transactionIndex);
 
-      const outRef = input.transaction_id().to_hex() + input.index().to_str();
+      const outRef = transactionId.to_hex() + transactionIndex.to_str();
 
       const entry = this.ledger[outRef] || this.mempool[outRef];
 
       if (!entry || entry.spent) {
         throw new Error(
-          `Could not read UTxO: ${
-            JSON.stringify({
-              txHash: entry?.utxo.txHash,
-              outputIndex: entry?.utxo.outputIndex,
-            })
-          }\nIt does not exist or was already spent.`,
+          `Could not read UTxO: ${JSON.stringify({
+            txHash: entry?.utxo.txHash,
+            outputIndex: entry?.utxo.outputIndex,
+          })}\nIt does not exist or was already spent.`
         );
       }
 
@@ -597,17 +659,24 @@ export class Emulator implements Provider {
     }
 
     // Check required signers
-
-    for (let i = 0; i < (body.required_signers()?.len() || 0); i++) {
-      const signer = body.required_signers()!.get(i);
+    const requiredSigners = body.required_signers();
+    bucket.push(requiredSigners);
+    for (let i = 0; i < (requiredSigners?.len() || 0); i++) {
+      const signer = requiredSigners!.get(i);
+      bucket.push(signer);
       checkAndConsumeHash({ type: "Key", hash: signer.to_hex() }, null, null);
     }
 
     // Check mint witnesses
-
-    for (let index = 0; index < (body.mint()?.keys().len() || 0); index++) {
-      const policyId = body.mint()!.keys().get(index).to_hex();
-      checkAndConsumeHash({ type: "Script", hash: policyId }, "Mint", index);
+    const mint = body.mint();
+    bucket.push(mint);
+    const mintKeys = mint?.keys();
+    bucket.push(mintKeys);
+    for (let index = 0; index < (mintKeys?.len() || 0); index++) {
+      const policy = mintKeys!.get(index);
+      bucket.push(policy);
+      const hash = policy.to_hex();
+      checkAndConsumeHash({ type: "Script", hash }, "Mint", index);
     }
 
     // Check withdrawal witnesses
@@ -617,23 +686,22 @@ export class Emulator implements Provider {
       withdrawal: Lovelace;
     }[] = [];
 
-    for (
-      let index = 0;
-      index < (body.withdrawals()?.keys().len() || 0);
-      index++
-    ) {
-      const rawAddress = body.withdrawals()!.keys().get(index);
-      const withdrawal: Lovelace = BigInt(
-        body.withdrawals()!.get(rawAddress)!.to_str(),
-      );
-      const rewardAddress = rawAddress.to_address().to_bech32(undefined);
-      const { stakeCredential } = getAddressDetails(
-        rewardAddress,
-      );
+    const withdrawals = body.withdrawals();
+    const withdrawalKeys = withdrawals?.keys();
+    for (let index = 0; index < (withdrawalKeys?.len() || 0); index++) {
+      const rawAddress = withdrawalKeys!.get(index);
+      bucket.push(rawAddress);
+      const cWithdrawal = withdrawals!.get(rawAddress);
+      bucket.push(cWithdrawal);
+      const withdrawal: Lovelace = BigInt(cWithdrawal!.to_str());
+      const cAddress = rawAddress.to_address();
+      bucket.push(cAddress);
+      const rewardAddress = cAddress.to_bech32(undefined);
+      const { stakeCredential } = getAddressDetails(rewardAddress);
       checkAndConsumeHash(stakeCredential!, "Reward", index);
       if (this.chain[rewardAddress]?.delegation.rewards !== withdrawal) {
         throw new Error(
-          "Withdrawal amount doesn't match actual reward balance.",
+          "Withdrawal amount doesn't match actual reward balance."
         );
       }
       withdrawalRequests.push({ rewardAddress, withdrawal });
@@ -647,7 +715,9 @@ export class Emulator implements Provider {
       poolId?: PoolId;
     }[] = [];
 
-    for (let index = 0; index < (body.certs()?.len() || 0); index++) {
+    const certs = body.certs();
+    bucket.push(certs);
+    for (let index = 0; index < (certs?.len() || 0); index++) {
       /*
         Checking only:
         1. Stake registration
@@ -656,17 +726,27 @@ export class Emulator implements Provider {
 
         All other certificate types are not checked and considered valid.
       */
-      const cert = body.certs()!.get(index);
+      const cert = certs!.get(index);
+      bucket.push(cert);
       switch (cert.kind()) {
         case 0: {
           const registration = cert.as_stake_registration()!;
-          const rewardAddress = C.RewardAddress.new(
-            C.NetworkInfo.testnet().network_id(),
-            registration.stake_credential(),
-          ).to_address().to_bech32(undefined);
+          bucket.push(registration);
+          const networkInfo = C.NetworkInfo.testnet();
+          bucket.push(networkInfo);
+          const stakeCredential = registration.stake_credential();
+          bucket.push(stakeCredential);
+          const cRewardAddress = C.RewardAddress.new(
+            networkInfo.network_id(),
+            stakeCredential
+          );
+          bucket.push(cRewardAddress);
+          const address = cRewardAddress.to_address();
+          bucket.push(address);
+          const rewardAddress = address.to_bech32(undefined);
           if (this.chain[rewardAddress]?.registeredStake) {
             throw new Error(
-              `Stake key is already registered. Reward address: ${rewardAddress}`,
+              `Stake key is already registered. Reward address: ${rewardAddress}`
             );
           }
           certRequests.push({ type: "Registration", rewardAddress });
@@ -674,17 +754,26 @@ export class Emulator implements Provider {
         }
         case 1: {
           const deregistration = cert.as_stake_deregistration()!;
-          const rewardAddress = C.RewardAddress.new(
-            C.NetworkInfo.testnet().network_id(),
-            deregistration.stake_credential(),
-          ).to_address().to_bech32(undefined);
+          bucket.push(deregistration);
+          const networkInfo = C.NetworkInfo.testnet();
+          bucket.push(networkInfo);
+          const cStakeCredential = deregistration.stake_credential();
+          bucket.push(cStakeCredential);
+          const cRewardAddress = C.RewardAddress.new(
+            networkInfo.network_id(),
+            cStakeCredential
+          );
+          bucket.push(cRewardAddress);
+          const address = cRewardAddress.to_address();
+          bucket.push(address);
+          const rewardAddress = address.to_bech32(undefined);
 
           const { stakeCredential } = getAddressDetails(rewardAddress);
           checkAndConsumeHash(stakeCredential!, "Cert", index);
 
           if (!this.chain[rewardAddress]?.registeredStake) {
             throw new Error(
-              `Stake key is already deregistered. Reward address: ${rewardAddress}`,
+              `Stake key is already deregistered. Reward address: ${rewardAddress}`
             );
           }
           certRequests.push({ type: "Deregistration", rewardAddress });
@@ -692,24 +781,36 @@ export class Emulator implements Provider {
         }
         case 2: {
           const delegation = cert.as_stake_delegation()!;
-          const rewardAddress = C.RewardAddress.new(
-            C.NetworkInfo.testnet().network_id(),
-            delegation.stake_credential(),
-          ).to_address().to_bech32(undefined);
-          const poolId = delegation.pool_keyhash().to_bech32("pool");
+          bucket.push(delegation);
+          const networkInfo = C.NetworkInfo.testnet();
+          bucket.push(networkInfo);
+          const cStakeCredential = delegation.stake_credential();
+          bucket.push(cStakeCredential);
+          const cRewardAddress = C.RewardAddress.new(
+            networkInfo.network_id(),
+            cStakeCredential
+          );
+          bucket.push(cRewardAddress);
+          const address = cRewardAddress.to_address();
+          bucket.push(address);
+          const rewardAddress = address.to_bech32(undefined);
+          const poolKeyHash = delegation.pool_keyhash();
+          bucket.push(poolKeyHash);
+          const poolId = poolKeyHash.to_bech32("pool");
 
           const { stakeCredential } = getAddressDetails(rewardAddress);
           checkAndConsumeHash(stakeCredential!, "Cert", index);
 
           if (
             !this.chain[rewardAddress]?.registeredStake &&
-            !certRequests.find((request) =>
-              request.type === "Registration" &&
-              request.rewardAddress === rewardAddress
+            !certRequests.find(
+              (request) =>
+                request.type === "Registration" &&
+                request.rewardAddress === rewardAddress
             )
           ) {
             throw new Error(
-              `Stake key is not registered. Reward address: ${rewardAddress}`,
+              `Stake key is not registered. Reward address: ${rewardAddress}`
             );
           }
           certRequests.push({ type: "Delegation", rewardAddress, poolId });
@@ -727,60 +828,65 @@ export class Emulator implements Provider {
 
     // Create outputs and consume datum hashes
     const outputs = (() => {
+      const outputs = body.outputs();
+      bucket.push(outputs);
       const collected = [];
-      for (let i = 0; i < body.outputs().len(); i++) {
-        const output = body.outputs().get(i);
+      for (let i = 0; i < outputs.len(); i++) {
+        const output = outputs.get(i);
+        bucket.push(output);
+        const transactionHash = C.TransactionHash.from_hex(txHash);
+        bucket.push(transactionHash);
+        const index = C.BigNum.from_str(i.toString());
+        bucket.push(index);
+        const transactionInput = C.TransactionInput.new(transactionHash, index);
+        bucket.push(transactionInput);
         const unspentOutput = C.TransactionUnspentOutput.new(
-          C.TransactionInput.new(
-            C.TransactionHash.from_hex(txHash),
-            C.BigNum.from_str(i.toString()),
-          ),
-          output,
+          transactionInput,
+          output
         );
+        bucket.push(unspentOutput);
 
         const utxo = coreToUtxo(unspentOutput);
 
         if (utxo.datumHash) consumedHashes.add(utxo.datumHash);
 
-        collected.push(
-          {
-            utxo,
-            spent: false,
-          },
-        );
+        collected.push({
+          utxo,
+          spent: false,
+        });
       }
       return collected;
     })();
 
     // Check consumed witnesses
 
-    const [extraKeyHash] = keyHashes.filter((keyHash) =>
-      !consumedHashes.has(keyHash)
+    const [extraKeyHash] = keyHashes.filter(
+      (keyHash) => !consumedHashes.has(keyHash)
     );
     if (extraKeyHash) {
       throw new Error(`Extraneous vkey witness. Key hash: ${extraKeyHash}`);
     }
 
-    const [extraNativeHash] = nativeHashes.filter((scriptHash) =>
-      !consumedHashes.has(scriptHash)
+    const [extraNativeHash] = nativeHashes.filter(
+      (scriptHash) => !consumedHashes.has(scriptHash)
     );
     if (extraNativeHash) {
       throw new Error(
-        `Extraneous native script. Script hash: ${extraNativeHash}`,
+        `Extraneous native script. Script hash: ${extraNativeHash}`
       );
     }
 
-    const [extraPlutusHash] = plutusHashes.filter((scriptHash) =>
-      !consumedHashes.has(scriptHash)
+    const [extraPlutusHash] = plutusHashes.filter(
+      (scriptHash) => !consumedHashes.has(scriptHash)
     );
     if (extraPlutusHash) {
       throw new Error(
-        `Extraneous plutus script. Script hash: ${extraPlutusHash}`,
+        `Extraneous plutus script. Script hash: ${extraPlutusHash}`
       );
     }
 
-    const [extraDatumHash] = Object.keys(datumTable).filter((datumHash) =>
-      !consumedHashes.has(datumHash)
+    const [extraDatumHash] = Object.keys(datumTable).filter(
+      (datumHash) => !consumedHashes.has(datumHash)
     );
     if (extraDatumHash) {
       throw new Error(`Extraneous plutus data. Datum hash: ${extraDatumHash}`);
@@ -888,21 +994,15 @@ export class Emulator implements Provider {
       "color:white",
       "color:yellow",
       "color:white",
-      "color:yellow",
+      "color:yellow"
     );
     console.log("\n");
     for (const [address, assets] of Object.entries(balances)) {
-      console.log(
-        `Address: %c${address}`,
-        "color:blue",
-        "\n",
-      );
+      console.log(`Address: %c${address}`, "color:blue", "\n");
       for (const [unit, quantity] of Object.entries(assets)) {
         const barLength = Math.max(
-          Math.floor(
-            60 * (Number(quantity) / Number(totalBalances[unit])),
-          ),
-          1,
+          Math.floor(60 * (Number(quantity) / Number(totalBalances[unit]))),
+          1
         );
         console.log(
           `%c${"\u2586".repeat(barLength) + " ".repeat(60 - barLength)}`,
@@ -910,12 +1010,10 @@ export class Emulator implements Provider {
           "",
           `${unit}:`,
           quantity,
-          "",
+          ""
         );
       }
-      console.log(
-        `\n${"\u2581".repeat(60)}\n`,
-      );
+      console.log(`\n${"\u2581".repeat(60)}\n`);
     }
   }
 }

--- a/src/provider/kupmios.ts
+++ b/src/provider/kupmios.ts
@@ -36,22 +36,23 @@ export class Kupmios implements Provider {
     });
 
     return new Promise((res, rej) => {
-      client.addEventListener("message", (msg: MessageEvent<string>) => {
-        try {
-          const { result } = JSON.parse(msg.data);
+      client.addEventListener(
+        "message",
+        (msg: MessageEvent<string>) => {
+          try {
+            const { result } = JSON.parse(msg.data);
 
-          // deno-lint-ignore no-explicit-any
-          const costModels: any = {};
-          Object.keys(result.costModels).forEach((v) => {
-            const version = v.split(":")[1].toUpperCase();
-            const plutusVersion = "Plutus" + version;
-            costModels[plutusVersion] = result.costModels[v];
-          });
-          const [memNum, memDenom] = result.prices.memory.split("/");
-          const [stepsNum, stepsDenom] = result.prices.steps.split("/");
+            // deno-lint-ignore no-explicit-any
+            const costModels: any = {};
+            Object.keys(result.costModels).forEach((v) => {
+              const version = v.split(":")[1].toUpperCase();
+              const plutusVersion = "Plutus" + version;
+              costModels[plutusVersion] = result.costModels[v];
+            });
+            const [memNum, memDenom] = result.prices.memory.split("/");
+            const [stepsNum, stepsDenom] = result.prices.steps.split("/");
 
-          res(
-            {
+            res({
               minFeeA: parseInt(result.minFeeCoefficient),
               minFeeB: parseInt(result.minFeeConstant),
               maxTxSize: parseInt(result.maxTxSize),
@@ -62,19 +63,20 @@ export class Kupmios implements Provider {
               priceStep: parseInt(stepsNum) / parseInt(stepsDenom),
               maxTxExMem: BigInt(result.maxExecutionUnitsPerTransaction.memory),
               maxTxExSteps: BigInt(
-                result.maxExecutionUnitsPerTransaction.steps,
+                result.maxExecutionUnitsPerTransaction.steps
               ),
               coinsPerUtxoByte: BigInt(result.coinsPerUtxoByte),
               collateralPercentage: parseInt(result.collateralPercentage),
               maxCollateralInputs: parseInt(result.maxCollateralInputs),
               costModels,
-            },
-          );
-          client.close();
-        } catch (e) {
-          rej(e);
-        }
-      }, { once: true });
+            });
+            client.close();
+          } catch (e) {
+            rej(e);
+          }
+        },
+        { once: true }
+      );
     });
   }
 
@@ -86,15 +88,14 @@ export class Kupmios implements Provider {
     const result = await fetch(
       `${this.kupoUrl}/matches/${queryPredicate}${
         isAddress ? "" : "/*"
-      }?unspent`,
-    )
-      .then((res) => res.json());
+      }?unspent`
+    ).then((res) => res.json());
     return this.kupmiosUtxosToUtxos(result);
   }
 
   async getUtxosWithUnit(
     addressOrCredential: Address | Credential,
-    unit: Unit,
+    unit: Unit
   ): Promise<UTxO[]> {
     const isAddress = typeof addressOrCredential === "string";
     const queryPredicate = isAddress
@@ -106,9 +107,8 @@ export class Kupmios implements Provider {
         isAddress ? "" : "/*"
       }?unspent&policy_id=${policyId}${
         assetName ? `&asset_name=${assetName}` : ""
-      }`,
-    )
-      .then((res) => res.json());
+      }`
+    ).then((res) => res.json());
     return this.kupmiosUtxosToUtxos(result);
   }
 
@@ -117,9 +117,8 @@ export class Kupmios implements Provider {
     const result = await fetch(
       `${this.kupoUrl}/matches/${policyId}.${
         assetName ? `${assetName}` : "*"
-      }?unspent`,
-    )
-      .then((res) => res.json());
+      }?unspent`
+    ).then((res) => res.json());
 
     const utxos = await this.kupmiosUtxosToUtxos(result);
 
@@ -133,51 +132,59 @@ export class Kupmios implements Provider {
   async getUtxosByOutRef(outRefs: Array<OutRef>): Promise<UTxO[]> {
     const queryHashes = [...new Set(outRefs.map((outRef) => outRef.txHash))];
 
-    const utxos = await Promise.all(queryHashes.map(async (txHash) => {
-      const result = await fetch(
-        `${this.kupoUrl}/matches/*@${txHash}?unspent`,
-      ).then((res) => res.json());
-      return this.kupmiosUtxosToUtxos(result);
-    }));
-
-    return utxos.reduce((acc, utxos) => acc.concat(utxos), []).filter((utxo) =>
-      outRefs.some((outRef) =>
-        utxo.txHash === outRef.txHash && utxo.outputIndex === outRef.outputIndex
-      )
+    const utxos = await Promise.all(
+      queryHashes.map(async (txHash) => {
+        const result = await fetch(
+          `${this.kupoUrl}/matches/*@${txHash}?unspent`
+        ).then((res) => res.json());
+        return this.kupmiosUtxosToUtxos(result);
+      })
     );
+
+    return utxos
+      .reduce((acc, utxos) => acc.concat(utxos), [])
+      .filter((utxo) =>
+        outRefs.some(
+          (outRef) =>
+            utxo.txHash === outRef.txHash &&
+            utxo.outputIndex === outRef.outputIndex
+        )
+      );
   }
 
   async getDelegation(rewardAddress: RewardAddress): Promise<Delegation> {
     const client = await this.ogmiosWsp("Query", {
-      query: { "delegationsAndRewards": [rewardAddress] },
+      query: { delegationsAndRewards: [rewardAddress] },
     });
 
     return new Promise((res, rej) => {
-      client.addEventListener("message", (msg: MessageEvent<string>) => {
-        try {
-          const { result } = JSON.parse(msg.data);
-          const delegation = (result ? Object.values(result)[0] : {}) as {
-            delegate: string;
-            rewards: number;
-          };
-          res(
-            {
+      client.addEventListener(
+        "message",
+        (msg: MessageEvent<string>) => {
+          try {
+            const { result } = JSON.parse(msg.data);
+            const delegation = (result ? Object.values(result)[0] : {}) as {
+              delegate: string;
+              rewards: number;
+            };
+            res({
               poolId: delegation?.delegate || null,
               rewards: BigInt(delegation?.rewards || 0),
-            },
-          );
-          client.close();
-        } catch (e) {
-          rej(e);
-        }
-      }, { once: true });
+            });
+            client.close();
+          } catch (e) {
+            rej(e);
+          }
+        },
+        { once: true }
+      );
     });
   }
 
   async getDatum(datumHash: DatumHash): Promise<Datum> {
-    const result = await fetch(
-      `${this.kupoUrl}/datums/${datumHash}`,
-    ).then((res) => res.json());
+    const result = await fetch(`${this.kupoUrl}/datums/${datumHash}`).then(
+      (res) => res.json()
+    );
     if (!result || !result.datum) {
       throw new Error(`No datum found for datum hash: ${datumHash}`);
     }
@@ -188,7 +195,7 @@ export class Kupmios implements Provider {
     return new Promise((res) => {
       const confirmation = setInterval(async () => {
         const isConfirmed = await fetch(
-          `${this.kupoUrl}/matches/*@${txHash}?unspent`,
+          `${this.kupoUrl}/matches/*@${txHash}?unspent`
         ).then((res) => res.json());
         if (isConfirmed && isConfirmed.length > 0) {
           clearInterval(confirmation);
@@ -205,80 +212,94 @@ export class Kupmios implements Provider {
     });
 
     return new Promise((res, rej) => {
-      client.addEventListener("message", (msg: MessageEvent<string>) => {
-        try {
-          const { result } = JSON.parse(msg.data);
+      client.addEventListener(
+        "message",
+        (msg: MessageEvent<string>) => {
+          try {
+            const { result } = JSON.parse(msg.data);
 
-          if (result.SubmitSuccess) res(result.SubmitSuccess.txId);
-          else rej(result.SubmitFail);
-          client.close();
-        } catch (e) {
-          rej(e);
-        }
-      }, { once: true });
+            if (result.SubmitSuccess) res(result.SubmitSuccess.txId);
+            else rej(result.SubmitFail);
+            client.close();
+          } catch (e) {
+            rej(e);
+          }
+        },
+        { once: true }
+      );
     });
   }
 
   private kupmiosUtxosToUtxos(utxos: unknown): Promise<UTxO[]> {
-    // deno-lint-ignore no-explicit-any
-    return Promise.all((utxos as any).map(async (utxo: any) => {
-      return ({
-        txHash: utxo.transaction_id,
-        outputIndex: parseInt(utxo.output_index),
-        address: utxo.address,
-        assets: (() => {
-          const a: Assets = { lovelace: BigInt(utxo.value.coins) };
-          Object.keys(utxo.value.assets).forEach((unit) => {
-            a[unit.replace(".", "")] = BigInt(utxo.value.assets[unit]);
-          });
-          return a;
-        })(),
-        datumHash: utxo?.datum_type === "hash" ? utxo.datum_hash : null,
-        datum: utxo?.datum_type === "inline"
-          ? await this.getDatum(utxo.datum_hash)
-          : null,
-        scriptRef: utxo.script_hash &&
-          (await (async () => {
-            const {
-              script,
-              language,
-            } = await fetch(
-              `${this.kupoUrl}/scripts/${utxo.script_hash}`,
-            ).then((res) => res.json());
+    return Promise.all(
+      // deno-lint-ignore no-explicit-any
+      (utxos as any).map(async (utxo: any) => {
+        return {
+          txHash: utxo.transaction_id,
+          outputIndex: parseInt(utxo.output_index),
+          address: utxo.address,
+          assets: (() => {
+            const a: Assets = { lovelace: BigInt(utxo.value.coins) };
+            Object.keys(utxo.value.assets).forEach((unit) => {
+              a[unit.replace(".", "")] = BigInt(utxo.value.assets[unit]);
+            });
+            return a;
+          })(),
+          datumHash: utxo?.datum_type === "hash" ? utxo.datum_hash : null,
+          datum:
+            utxo?.datum_type === "inline"
+              ? await this.getDatum(utxo.datum_hash)
+              : null,
+          scriptRef:
+            utxo.script_hash &&
+            (await (async () => {
+              const { script, language } = await fetch(
+                `${this.kupoUrl}/scripts/${utxo.script_hash}`
+              ).then((res) => res.json());
 
-            if (language === "native") {
-              return { type: "Native", script };
-            } else if (language === "plutus:v1") {
-              return {
-                type: "PlutusV1",
-                script: toHex(C.PlutusScript.new(fromHex(script)).to_bytes()),
-              };
-            } else if (language === "plutus:v2") {
-              return {
-                type: "PlutusV2",
-                script: toHex(C.PlutusScript.new(fromHex(script)).to_bytes()),
-              };
-            }
-          })()),
-      }) as UTxO;
-    }));
+              if (language === "native") {
+                return { type: "Native", script };
+              } else if (language === "plutus:v1") {
+                const plutusScript = C.PlutusScript.new(fromHex(script));
+                const scriptBytes = plutusScript.to_bytes();
+                plutusScript.free();
+                return {
+                  type: "PlutusV1",
+                  script: toHex(scriptBytes),
+                };
+              } else if (language === "plutus:v2") {
+                const plutusScript = C.PlutusScript.new(fromHex(script));
+                const scriptBytes = plutusScript.to_bytes();
+                plutusScript.free();
+
+                return {
+                  type: "PlutusV2",
+                  script: toHex(scriptBytes),
+                };
+              }
+            })()),
+        } as UTxO;
+      })
+    );
   }
 
   private async ogmiosWsp(
     methodname: string,
-    args: unknown,
+    args: unknown
   ): Promise<WebSocket> {
     const client = new WebSocket(this.ogmiosUrl);
     await new Promise((res) => {
       client.addEventListener("open", () => res(1), { once: true });
     });
-    client.send(JSON.stringify({
-      type: "jsonwsp/request",
-      version: "1.0",
-      servicename: "ogmios",
-      methodname,
-      args,
-    }));
+    client.send(
+      JSON.stringify({
+        type: "jsonwsp/request",
+        version: "1.0",
+        servicename: "ogmios",
+        methodname,
+        args,
+      })
+    );
     return client;
   }
 }

--- a/src/utils/cml.ts
+++ b/src/utils/cml.ts
@@ -1,0 +1,245 @@
+import {
+  Address,
+  C,
+  CertificateValidator,
+  Datum,
+  Lucid,
+  MintingPolicy,
+  OutputData,
+  PoolParams,
+  Redeemer,
+  RewardAddress,
+  SpendingValidator,
+  Tx,
+  WithdrawalValidator,
+  applyDoubleCborEncoding,
+  fromHex,
+  networkToId,
+} from "../mod.ts";
+import { FreeableBucket, Freeables } from "./freeable.ts";
+
+export function getScriptWitness(
+  redeemer: Redeemer,
+  datum?: Datum
+): C.ScriptWitness {
+  const bucket: FreeableBucket = [];
+  try {
+    const plutusRedeemer = C.PlutusData.from_bytes(fromHex(redeemer!));
+    const plutusData = datum
+      ? C.PlutusData.from_bytes(fromHex(datum))
+      : undefined;
+    const plutusWitness = C.PlutusWitness.new(
+      plutusRedeemer,
+      plutusData,
+      undefined
+    );
+    // We shouldn't free plutusData as it is an Option
+    bucket.push(plutusRedeemer, plutusWitness);
+    return C.ScriptWitness.new_plutus_witness(plutusWitness);
+  } finally {
+    Freeables.free(...bucket);
+  }
+}
+
+export function getStakeCredential(hash: string, type: "Key" | "Script") {
+  if (type === "Key") {
+    const keyHash = C.Ed25519KeyHash.from_bytes(fromHex(hash));
+    const credential = C.StakeCredential.from_keyhash(keyHash);
+    Freeables.free(keyHash);
+    return credential;
+  }
+  const scriptHash = C.ScriptHash.from_bytes(fromHex(hash));
+  const credential = C.StakeCredential.from_scripthash(scriptHash);
+  Freeables.free(scriptHash);
+  return credential;
+}
+
+export async function createPoolRegistration(
+  poolParams: PoolParams,
+  lucid: Lucid
+): Promise<C.PoolRegistration> {
+  const bucket: FreeableBucket = [];
+  try {
+    const poolOwners = C.Ed25519KeyHashes.new();
+    bucket.push(poolOwners);
+    poolParams.owners.forEach((owner) => {
+      const { stakeCredential } = lucid.utils.getAddressDetails(owner);
+      if (stakeCredential?.type === "Key") {
+        const keyHash = C.Ed25519KeyHash.from_hex(stakeCredential.hash);
+        poolOwners.add(keyHash);
+        bucket.push(keyHash);
+      } else throw new Error("Only key hashes allowed for pool owners.");
+    });
+
+    const metadata = poolParams.metadataUrl
+      ? await fetch(poolParams.metadataUrl).then((res) => res.arrayBuffer())
+      : null;
+
+    const metadataHash = metadata
+      ? C.PoolMetadataHash.from_bytes(
+          C.hash_blake2b256(new Uint8Array(metadata))
+        )
+      : null;
+
+    const relays = C.Relays.new();
+    bucket.push(metadataHash, relays);
+    poolParams.relays.forEach((relay) => {
+      switch (relay.type) {
+        case "SingleHostIp": {
+          const ipV4 = relay.ipV4
+            ? C.Ipv4.new(
+                new Uint8Array(relay.ipV4.split(".").map((b) => parseInt(b)))
+              )
+            : undefined;
+          const ipV6 = relay.ipV6
+            ? C.Ipv6.new(fromHex(relay.ipV6.replaceAll(":", "")))
+            : undefined;
+          const host = C.SingleHostAddr.new(relay.port, ipV4, ipV6);
+          const newRelay = C.Relay.new_single_host_addr(host);
+          //We shouldn't free ipV4 and ipV6 as they are optionals
+          bucket.push(host, newRelay);
+          relays.add(newRelay);
+          break;
+        }
+        case "SingleHostDomainName": {
+          const record = C.DNSRecordAorAAAA.new(relay.domainName!);
+          const host = C.SingleHostName.new(relay.port, record);
+          const newRelay = C.Relay.new_single_host_name(host);
+          bucket.push(record, host, newRelay);
+          relays.add(newRelay);
+          break;
+        }
+        case "MultiHost": {
+          const record = C.DNSRecordSRV.new(relay.domainName!);
+          const host = C.MultiHostName.new(record);
+          const newRelay = C.Relay.new_multi_host_name(host);
+          bucket.push(record, host, newRelay);
+          relays.add(newRelay);
+          break;
+        }
+      }
+    });
+
+    const operator = C.Ed25519KeyHash.from_bech32(poolParams.poolId);
+    const vrfKeyHash = C.VRFKeyHash.from_hex(poolParams.vrfKeyHash);
+    const pledge = C.BigNum.from_str(poolParams.pledge.toString());
+    const cost = C.BigNum.from_str(poolParams.cost.toString());
+
+    const margin = C.UnitInterval.from_float(poolParams.margin);
+    const addr = addressFromWithNetworkCheck(poolParams.rewardAddress, lucid);
+    const rewardAddress = C.RewardAddress.from_address(addr);
+    const url = C.Url.new(poolParams.metadataUrl!);
+    const poolMetadata = metadataHash
+      ? C.PoolMetadata.new(url, metadataHash)
+      : undefined;
+    bucket.push(
+      operator,
+      vrfKeyHash,
+      pledge,
+      cost,
+      margin,
+      addr,
+      rewardAddress,
+      url,
+      poolMetadata
+    );
+
+    const params = C.PoolParams.new(
+      operator,
+      vrfKeyHash,
+      pledge,
+      cost,
+      margin,
+      rewardAddress!,
+      poolOwners,
+      relays,
+      poolMetadata
+    );
+
+    const poolRegistration = C.PoolRegistration.new(params);
+    return poolRegistration;
+  } finally {
+    Freeables.free(...bucket);
+  }
+}
+
+export function attachScript(
+  tx: Tx,
+  {
+    type,
+    script,
+  }:
+    | SpendingValidator
+    | MintingPolicy
+    | CertificateValidator
+    | WithdrawalValidator
+) {
+  if (type === "Native") {
+    const nativeScript = C.NativeScript.from_bytes(fromHex(script));
+    tx.txBuilder.add_native_script(nativeScript);
+    Freeables.free(nativeScript);
+    return;
+  } else if (type === "PlutusV1") {
+    const plutusScript = C.PlutusScript.from_bytes(
+      fromHex(applyDoubleCborEncoding(script))
+    );
+    tx.txBuilder.add_plutus_script(plutusScript);
+    Freeables.free(plutusScript);
+    return;
+  } else if (type === "PlutusV2") {
+    const plutusScript = C.PlutusScript.from_bytes(
+      fromHex(applyDoubleCborEncoding(script))
+    );
+    tx.txBuilder.add_plutus_v2_script(plutusScript);
+    Freeables.free(plutusScript);
+    return;
+  }
+  throw new Error("No variant matched.");
+}
+
+export function addressFromWithNetworkCheck(
+  address: Address | RewardAddress,
+  lucid: Lucid
+): C.Address {
+  const { type, networkId } = lucid.utils.getAddressDetails(address);
+
+  const actualNetworkId = networkToId(lucid.network);
+  if (networkId !== actualNetworkId) {
+    throw new Error(
+      `Invalid address: Expected address with network id ${actualNetworkId}, but got ${networkId}`
+    );
+  }
+  if (type === "Byron") {
+    const byron = C.ByronAddress.from_base58(address);
+    const addr = byron.to_address();
+    byron.free();
+    return addr;
+  }
+  return C.Address.from_bech32(address);
+}
+
+export function getDatumFromOutputData(outputData?: OutputData): {
+  datum?: C.Datum | undefined;
+  plutusData?: C.PlutusData;
+} {
+  if (outputData?.hash) {
+    const hash = C.DataHash.from_hex(outputData.hash);
+    const datum = C.Datum.new_data_hash(hash);
+    hash.free();
+    return { datum };
+  } else if (outputData?.asHash) {
+    const plutusData = C.PlutusData.from_bytes(fromHex(outputData.asHash));
+    const dataHash = C.hash_plutus_data(plutusData);
+    const datum = C.Datum.new_data_hash(dataHash);
+    dataHash.free();
+    return { plutusData, datum };
+  } else if (outputData?.inline) {
+    const plutusData = C.PlutusData.from_bytes(fromHex(outputData.inline));
+    const data = C.Data.new(plutusData);
+    const datum = C.Datum.new_data(data);
+    Freeables.free(plutusData, data);
+    return { datum };
+  } else {
+    return {};
+  }
+}

--- a/src/utils/freeable.ts
+++ b/src/utils/freeable.ts
@@ -1,0 +1,13 @@
+export interface Freeable {
+  free(): void;
+}
+
+export type FreeableBucket = Array<Freeable | undefined>;
+
+export abstract class Freeables {
+  static free(...bucket: (Freeable | undefined)[]) {
+    bucket.forEach((freeable) => {
+      freeable?.free();
+    });
+  }
+}

--- a/src/utils/freeable.ts
+++ b/src/utils/freeable.ts
@@ -1,9 +1,29 @@
+/**
+ * These types and classes are used to help with freeing memory.
+ * Objects passed from the WASM to JS (Objects from Rust libraries, for example) are not freed automatically, or at least inconsistently.
+ * This can lead to memory leaks.
+ * In order to free these objects, we need to call the `free()` method on them. These types make it easier.
+ */
+
+/** This interface represents WASM objects that can and need to be freed. */
 export interface Freeable {
   free(): void;
 }
 
 export type FreeableBucket = Array<Freeable | undefined | null>;
 
+/** This class makes it easier to free large sets of memory. It can be used like this:
+ * ```ts
+ * const bucket: FreeableBucket = [];
+ * try {
+ *    const rustObject = C.some_rust_object();
+ *    bucket.push(rustObject);
+ *    ...
+ * } finally {
+ *    Freeables.free(...bucket);
+ * }
+ * ```
+ */
 export abstract class Freeables {
   static free(...bucket: FreeableBucket) {
     bucket.forEach((freeable) => {

--- a/src/utils/freeable.ts
+++ b/src/utils/freeable.ts
@@ -2,10 +2,10 @@ export interface Freeable {
   free(): void;
 }
 
-export type FreeableBucket = Array<Freeable | undefined>;
+export type FreeableBucket = Array<Freeable | undefined | null>;
 
 export abstract class Freeables {
-  static free(...bucket: (Freeable | undefined)[]) {
+  static free(...bucket: FreeableBucket) {
     bucket.forEach((freeable) => {
       freeable?.free();
     });

--- a/src/utils/mod.ts
+++ b/src/utils/mod.ts
@@ -1,3 +1,5 @@
 export * from "./cost_model.ts";
 export * from "./utils.ts";
 export * from "./merkle_tree.ts";
+export * from "./cml.ts";
+export * from "./freeable.ts";

--- a/src/utils/transaction_builder_config.ts
+++ b/src/utils/transaction_builder_config.ts
@@ -9,13 +9,13 @@ export function getTransactionBuilderConfig(
   blockfrostConfig: {
     url?: string;
     projectId?: string;
-  }
+  },
 ) {
   const bucket: Freeable[] = [];
   let builderA = C.TransactionBuilderConfigBuilder.new();
 
   const coinsPerUtxoByte = C.BigNum.from_str(
-    protocolParameters.coinsPerUtxoByte.toString()
+    protocolParameters.coinsPerUtxoByte.toString(),
   );
   bucket.push(coinsPerUtxoByte);
   let builderB = builderA.coins_per_utxo_byte(coinsPerUtxoByte);
@@ -31,14 +31,14 @@ export function getTransactionBuilderConfig(
   builderB.free();
 
   const keyDeposit = C.BigNum.from_str(
-    protocolParameters.keyDeposit.toString()
+    protocolParameters.keyDeposit.toString(),
   );
   bucket.push(keyDeposit);
   builderB = builderA.key_deposit(keyDeposit);
   builderA.free();
 
   const poolDeposit = C.BigNum.from_str(
-    protocolParameters.poolDeposit.toString()
+    protocolParameters.poolDeposit.toString(),
   );
   bucket.push(poolDeposit);
   builderA = builderB.pool_deposit(poolDeposit);
@@ -51,21 +51,21 @@ export function getTransactionBuilderConfig(
   builderB.free();
 
   builderB = builderA.collateral_percentage(
-    protocolParameters.collateralPercentage
+    protocolParameters.collateralPercentage,
   );
   builderA.free();
 
   builderA = builderB.max_collateral_inputs(
-    protocolParameters.maxCollateralInputs
+    protocolParameters.maxCollateralInputs,
   );
   builderB.free();
 
   const maxTxExMem = C.BigNum.from_str(
-    protocolParameters.maxTxExMem.toString()
+    protocolParameters.maxTxExMem.toString(),
   );
   bucket.push(maxTxExMem);
   const maxTxExSteps = C.BigNum.from_str(
-    protocolParameters.maxTxExSteps.toString()
+    protocolParameters.maxTxExSteps.toString(),
   );
   bucket.push(maxTxExSteps);
   const exUnits = C.ExUnits.new(maxTxExMem, maxTxExSteps);
@@ -75,7 +75,7 @@ export function getTransactionBuilderConfig(
 
   const exUnitPrices = C.ExUnitPrices.from_float(
     protocolParameters.priceMem,
-    protocolParameters.priceStep
+    protocolParameters.priceStep,
   );
   bucket.push(exUnitPrices);
   builderA = builderB.ex_unit_prices(exUnitPrices);
@@ -90,7 +90,7 @@ export function getTransactionBuilderConfig(
 
   const blockfrost = C.Blockfrost.new(
     blockfrostConfig?.url ?? "" + "utils/tx/evaulate",
-    blockfrostConfig?.projectId ?? ""
+    blockfrostConfig?.projectId ?? "",
   );
   bucket.push(blockfrost);
   builderA = builderB.blockfrost(blockfrost);

--- a/src/utils/transaction_builder_config.ts
+++ b/src/utils/transaction_builder_config.ts
@@ -1,0 +1,108 @@
+import { C, SlotConfig } from "../mod.ts";
+import { ProtocolParameters } from "../types/mod.ts";
+import { createCostModels } from "./cost_model.ts";
+import { Freeable, Freeables } from "./freeable.ts";
+
+export function getTransactionBuilderConfig(
+  protocolParameters: ProtocolParameters,
+  slotConfig: SlotConfig,
+  blockfrostConfig: {
+    url?: string;
+    projectId?: string;
+  }
+) {
+  const bucket: Freeable[] = [];
+  let builderA = C.TransactionBuilderConfigBuilder.new();
+
+  const coinsPerUtxoByte = C.BigNum.from_str(
+    protocolParameters.coinsPerUtxoByte.toString()
+  );
+  bucket.push(coinsPerUtxoByte);
+  let builderB = builderA.coins_per_utxo_byte(coinsPerUtxoByte);
+  builderA.free();
+
+  const minFeeA = C.BigNum.from_str(protocolParameters.minFeeA.toString());
+  bucket.push(minFeeA);
+  const minFeeB = C.BigNum.from_str(protocolParameters.minFeeB.toString());
+  bucket.push(minFeeB);
+  const linearFee = C.LinearFee.new(minFeeA, minFeeB);
+  bucket.push(linearFee);
+  builderA = builderB.fee_algo(linearFee);
+  builderB.free();
+
+  const keyDeposit = C.BigNum.from_str(
+    protocolParameters.keyDeposit.toString()
+  );
+  bucket.push(keyDeposit);
+  builderB = builderA.key_deposit(keyDeposit);
+  builderA.free();
+
+  const poolDeposit = C.BigNum.from_str(
+    protocolParameters.poolDeposit.toString()
+  );
+  bucket.push(poolDeposit);
+  builderA = builderB.pool_deposit(poolDeposit);
+  builderB.free();
+
+  builderB = builderA.max_tx_size(protocolParameters.maxTxSize);
+  builderA.free();
+
+  builderA = builderB.max_value_size(protocolParameters.maxValSize);
+  builderB.free();
+
+  builderB = builderA.collateral_percentage(
+    protocolParameters.collateralPercentage
+  );
+  builderA.free();
+
+  builderA = builderB.max_collateral_inputs(
+    protocolParameters.maxCollateralInputs
+  );
+  builderB.free();
+
+  const maxTxExMem = C.BigNum.from_str(
+    protocolParameters.maxTxExMem.toString()
+  );
+  bucket.push(maxTxExMem);
+  const maxTxExSteps = C.BigNum.from_str(
+    protocolParameters.maxTxExSteps.toString()
+  );
+  bucket.push(maxTxExSteps);
+  const exUnits = C.ExUnits.new(maxTxExMem, maxTxExSteps);
+  bucket.push(exUnits);
+  builderB = builderA.max_tx_ex_units(exUnits);
+  builderA.free();
+
+  const exUnitPrices = C.ExUnitPrices.from_float(
+    protocolParameters.priceMem,
+    protocolParameters.priceStep
+  );
+  bucket.push(exUnitPrices);
+  builderA = builderB.ex_unit_prices(exUnitPrices);
+  builderB.free();
+
+  const zeroTime = C.BigNum.from_str(slotConfig.zeroTime.toString());
+  bucket.push(zeroTime);
+  const zeroSlot = C.BigNum.from_str(slotConfig.zeroSlot.toString());
+  bucket.push(zeroSlot);
+  builderB = builderA.slot_config(zeroTime, zeroSlot, slotConfig.slotLength);
+  builderA.free();
+
+  const blockfrost = C.Blockfrost.new(
+    blockfrostConfig?.url ?? "" + "utils/tx/evaulate",
+    blockfrostConfig?.projectId ?? ""
+  );
+  bucket.push(blockfrost);
+  builderA = builderB.blockfrost(blockfrost);
+  builderB.free();
+
+  const costModels = createCostModels(protocolParameters.costModels);
+  bucket.push(costModels);
+  builderB = builderA.costmdls(costModels);
+
+  const config = builderB.build();
+  builderB.free();
+  Freeables.free(...bucket);
+
+  return config;
+}

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -966,15 +966,17 @@ export function fromUnit(unit: Unit): {
  * It follows this Json format: https://github.com/input-output-hk/cardano-node/blob/master/doc/reference/simple-scripts.md
  */
 export function nativeScriptFromJson(nativeScript: NativeScript): Script {
+  const cNativeScript = C.encode_json_str_to_native_script(
+    JSON.stringify(nativeScript),
+    "",
+    C.ScriptSchema.Node
+  );
+  const script = toHex(cNativeScript.to_bytes());
+  cNativeScript.free();
+
   return {
     type: "Native",
-    script: toHex(
-      C.encode_json_str_to_native_script(
-        JSON.stringify(nativeScript),
-        "",
-        C.ScriptSchema.Node
-      ).to_bytes()
-    ),
+    script,
   };
 }
 

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -224,25 +224,41 @@ export class Utils {
   }
 
   validatorToScriptHash(validator: Validator): ScriptHash {
-    switch (validator.type) {
-      case "Native":
-        return C.NativeScript.from_bytes(fromHex(validator.script))
-          .hash(C.ScriptHashNamespace.NativeScript)
-          .to_hex();
-      case "PlutusV1":
-        return C.PlutusScript.from_bytes(
-          fromHex(applyDoubleCborEncoding(validator.script))
-        )
-          .hash(C.ScriptHashNamespace.PlutusV1)
-          .to_hex();
-      case "PlutusV2":
-        return C.PlutusScript.from_bytes(
-          fromHex(applyDoubleCborEncoding(validator.script))
-        )
-          .hash(C.ScriptHashNamespace.PlutusV2)
-          .to_hex();
-      default:
-        throw new Error("No variant matched");
+    const bucket: FreeableBucket = [];
+    try {
+      switch (validator.type) {
+        case "Native": {
+          const nativeScript = C.NativeScript.from_bytes(
+            fromHex(validator.script)
+          );
+          bucket.push(nativeScript);
+          const hash = nativeScript.hash(C.ScriptHashNamespace.NativeScript);
+          bucket.push(hash);
+          return hash.to_hex();
+        }
+        case "PlutusV1": {
+          const plutusScript = C.PlutusScript.from_bytes(
+            fromHex(applyDoubleCborEncoding(validator.script))
+          );
+          bucket.push(plutusScript);
+          const hash = plutusScript.hash(C.ScriptHashNamespace.PlutusV1);
+          bucket.push(hash);
+          return hash.to_hex();
+        }
+        case "PlutusV2": {
+          const plutusScript = C.PlutusScript.from_bytes(
+            fromHex(applyDoubleCborEncoding(validator.script))
+          );
+          bucket.push(plutusScript);
+          const hash = plutusScript.hash(C.ScriptHashNamespace.PlutusV2);
+          bucket.push(hash);
+          return hash.to_hex();
+        }
+        default:
+          throw new Error("No variant matched");
+      }
+    } finally {
+      Freeables.free(...bucket);
     }
   }
 

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -603,23 +603,34 @@ export function generateSeedPhrase(): string {
 }
 
 export function valueToAssets(value: C.Value): Assets {
+  const bucket: FreeableBucket = [];
   const assets: Assets = {};
-  assets["lovelace"] = BigInt(value.coin().to_str());
+  const lovelace = value.coin();
+  bucket.push(lovelace);
+  assets["lovelace"] = BigInt(lovelace.to_str());
   const ma = value.multiasset();
+  bucket.push(ma);
   if (ma) {
     const multiAssets = ma.keys();
+    bucket.push(multiAssets);
     for (let j = 0; j < multiAssets.len(); j++) {
       const policy = multiAssets.get(j);
+      bucket.push(policy);
       const policyAssets = ma.get(policy)!;
+      bucket.push(policyAssets);
       const assetNames = policyAssets.keys();
+      bucket.push(assetNames);
       for (let k = 0; k < assetNames.len(); k++) {
         const policyAsset = assetNames.get(k);
+        bucket.push(policyAsset);
         const quantity = policyAssets.get(policyAsset)!;
+        bucket.push(quantity);
         const unit = toHex(policy.to_bytes()) + toHex(policyAsset.name());
         assets[unit] = BigInt(quantity.to_str());
       }
     }
   }
+  Freeables.free(...bucket);
   return assets;
 }
 

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -592,7 +592,10 @@ export function stakeCredentialOf(rewardAddress: RewardAddress): Credential {
 }
 
 export function generatePrivateKey(): PrivateKey {
-  return C.PrivateKey.generate_ed25519().to_bech32();
+  const ed25519 = C.PrivateKey.generate_ed25519();
+  const bech32 = ed25519.to_bech32();
+  ed25519.free();
+  return bech32;
 }
 
 export function generateSeedPhrase(): string {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1000,12 +1000,15 @@ export function applyParamsToScript<T extends unknown[] = Data[]>(
 /** Returns double cbor encoded script. If script is already double cbor encoded it's returned as it is. */
 export function applyDoubleCborEncoding(script: string): string {
   try {
-    C.PlutusScript.from_bytes(
-      C.PlutusScript.from_bytes(fromHex(script)).bytes()
-    );
+    const plutusScript = C.PlutusScript.from_bytes(fromHex(script));
+    const doublePlutusScript = C.PlutusScript.new(plutusScript.to_bytes());
+    Freeables.free(plutusScript, doublePlutusScript);
     return script;
   } catch (_e) {
-    return toHex(C.PlutusScript.new(fromHex(script)).to_bytes());
+    const plutusScript = C.PlutusScript.new(fromHex(script));
+    const bytes = plutusScript.to_bytes();
+    plutusScript.free();
+    return toHex(bytes);
   }
 }
 

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -889,7 +889,12 @@ export function fromText(text: string): string {
 }
 
 export function toPublicKey(privateKey: PrivateKey): PublicKey {
-  return C.PrivateKey.from_bech32(privateKey).to_public().to_bech32();
+  const sKey = C.PrivateKey.from_bech32(privateKey);
+  const vKey = sKey.to_public();
+  const bech32 = vKey.to_bech32();
+  Freeables.free(sKey, vKey);
+
+  return bech32;
 }
 
 /** Padded number in Hex. */

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -267,7 +267,12 @@ export class Utils {
   }
 
   datumToHash(datum: Datum): DatumHash {
-    return C.hash_plutus_data(C.PlutusData.from_bytes(fromHex(datum))).to_hex();
+    const plutusData = C.PlutusData.from_bytes(fromHex(datum));
+    const hash = C.hash_plutus_data(plutusData);
+    plutusData.free();
+    const datumHash = hash.to_hex();
+    hash.free();
+    return datumHash;
   }
 
   scriptHashToCredential(scriptHash: ScriptHash): Credential {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -986,12 +986,15 @@ export function applyParamsToScript<T extends unknown[] = Data[]>(
   type?: T
 ): string {
   const p = (type ? Data.castTo<T>(params, type) : params) as Data[];
-  return toHex(
-    C.apply_params_to_plutus_script(
-      C.PlutusList.from_bytes(fromHex(Data.to<Data[]>(p))),
-      C.PlutusScript.from_bytes(fromHex(applyDoubleCborEncoding(plutusScript)))
-    ).to_bytes()
+  const cPlutusScript = C.PlutusScript.from_bytes(
+    fromHex(applyDoubleCborEncoding(plutusScript))
   );
+  const cParams = C.PlutusList.from_bytes(fromHex(Data.to<Data[]>(p)));
+  const cScript = C.apply_params_to_plutus_script(cParams, cPlutusScript);
+  const script = toHex(cScript.to_bytes());
+  Freeables.free(cPlutusScript, cParams, cScript);
+
+  return script;
 }
 
 /** Returns double cbor encoded script. If script is already double cbor encoded it's returned as it is. */


### PR DESCRIPTION
At JPG Store, we have been dealing with memory leaks in our code that uses either Lucid or the CML. After some research, we discovered that the CML does a lot of `clone`s to avoid issues with freed memory across the WASM boundary ( https://github.com/dcSpark/cardano-multiplatform-lib/issues/142#issuecomment-1281810732). 

Any object that is returned from WASM to JavaScript seems to never get garbage collected. Thus, **all** objects returned from wasm to the js runtime must be freed, including intermediary values when chaining function calls together.

This PR specifically only fixes  the memory usage in the `Data.from` function to resolve the following issue: https://github.com/spacebudz/lucid/issues/222

I will continue to fix the memory management over time, as I have free time. However, I would argue it is best to merge these smaller pieces whenever they are done, as they will reduce the memory footprint of several applications relying on Lucid.