### PR TITLE
Fix: Handle protocal parameters fetch error

### DIFF
--- a/lib/provider/blockfrost.ts
+++ b/lib/provider/blockfrost.ts
@@ -29,6 +29,12 @@ export class Blockfrost implements Provider {
       headers: { project_id: this.projectId, lucid },
     }).then((res) => res.json());
 
+    if (!result) throw new Error("Failed to fetch protocal parameters");
+
+    if (result.error) {
+      throw new Error(`${result.status_code} ${result.error}:  ${result.message}`);
+    }
+
     return {
       minFeeA: parseInt(result.min_fee_a),
       minFeeB: parseInt(result.min_fee_b),


### PR DESCRIPTION
We were getting this error when the parameter fetch failed:
```sh
 ⨯ TypeError: Cannot convert undefined to a BigInt
```

This is the error that the fetch was returning.
```js
{
  error: 'Forbidden',
  message: 'Network token mismatch. Are you using token for the correct network? See https://blockfrost.dev/docs/start-building#available-networks',
  status_code: 403
}
```

This code will surface this error to the user when they forget to update their .env file ;)